### PR TITLE
Eval + EvalSHA params bombing out

### DIFF
--- a/src/carmine/commands.clj
+++ b/src/carmine/commands.clj
@@ -73,8 +73,7 @@
                        :arguments
                        [{:name "sha1"    :type "string"}
                         {:name "numkeys" :type "integer"}
-                        {:name "key"     :type "key"    :multiple true}
-                        {:name "arg"     :type "string" :multiple true}]})))
+                        {:name "keysandargs"     :type "key"    :multiple true}]})))
 
 (defmacro defcommands
   "Defines an appropriate function for every command in reference. If debug?

--- a/src/commands.json
+++ b/src/commands.json
@@ -225,13 +225,8 @@
         "type": "integer"
       },
       {
-        "name": "key",
+        "name": "keysandargs",
         "type": "key",
-        "multiple": true
-      },
-      {
-        "name": "arg",
-        "type": "string",
         "multiple": true
       }
     ],


### PR DESCRIPTION
The defcommand macro chokes on args if multiple ones are marked :multiple.  This fixes the situation.

Sorry I couldn't explain it too well on Twitter.  Thanks for this awesome library
