### PR TITLE
Making worker catch assertions errors

### DIFF
--- a/src/taoensso/carmine/message_queue.clj
+++ b/src/taoensso/carmine/message_queue.clj
@@ -135,7 +135,7 @@
                        (car/with-conn pool spec
                          (car/sadd (qkey qname "recently-done")
                                        message-id))
-                       (catch Exception e
+                       (catch Throwable e
                          (timbre/error
                           e (str "Exception while handling message from queue: "
                                  qname "\n") poll-reply))))))


### PR DESCRIPTION
This is a tiny fix in which throwable is catched, without this assertion errors (like in :pre) cause the work to die silently the background (took me some time to find) 
