### PR TITLE
Add ability for user to create their own (closeable) pools.

### DIFF
--- a/src/taoensso/carmine.clj
+++ b/src/taoensso/carmine.clj
@@ -26,9 +26,8 @@
                      :db 3}}
 
   For pool options, Ref. http://goo.gl/EiTbn."
-  [{:keys [pool spec] :as conn} & body]
-  `(let [[pool# spec#] [(conns/make-conn-pool ~pool)
-                        (conns/make-conn-spec ~spec)]
+  [conn & body]
+  `(let [{pool# :pool spec# :spec} (conns/make-memoized-specification ~conn)
          conn# (try (conns/get-conn pool# spec#)
                     (catch Exception e#
                       (throw (Exception. "Carmine connection error" e#))))]


### PR DESCRIPTION
See: https://github.com/ptaoussanis/carmine/issues/38

This is a (broad) commit that opens up the ability for the use to manage their own connection pools, as well as cleans up a bug in ConnectionPool which had a bad type-hint for it's pool in its close method.
