### PR TITLE
Add metadata to Redis API commands

### DIFF
--- a/src/taoensso/carmine/commands.clj
+++ b/src/taoensso/carmine/commands.clj
@@ -64,9 +64,15 @@
       `(println ~fn-name ":" \" ~(args->params-docstring args) \"
                 "->" ~(str fn-params))
       (if-not varps
-        `(defn ~(symbol fn-name) ~fn-docstring ~fn-params
+        `(defn ~(symbol fn-name)
+           {:doc ~fn-docstring
+            :redis-api true}
+           ~fn-params
            (protocol/send-request ~ps))
-        `(defn ~(symbol fn-name) ~fn-docstring ~fn-params
+        `(defn ~(symbol fn-name)
+           {:doc ~fn-docstring
+            :redis-api true}
+           ~fn-params
            (protocol/send-request (into ~ps ~varps)))))))
 
 (defn- get-command-reference


### PR DESCRIPTION
Add metadata to redis commands to differentiate between functions that
implement the Redis API and other carmine functions. This allows users
to quickly list out the core Redis API functions.
