### PR TITLE
Throw an ex-info in atomic macro

### DIFF
--- a/src/taoensso/carmine.clj
+++ b/src/taoensso/carmine.clj
@@ -345,8 +345,8 @@
                  ;; Was [] with < Carmine v3
                  (return r#)
                  (if (= idx# max-idx#)
-                   (throw (Exception. (format "`atomic` failed after %s attempt(s)"
-                                              idx#)))
+                   (throw (ex-info (format "`atomic` failed after %s attempt(s)")
+                                   {:source 'taoensso.carmine.atomic :idx idx#}))
                    (recur (inc idx#)))))))]
 
      [@prelude-result#


### PR DESCRIPTION
Backed out creation of new Exception type and other changes in wcar, but `atomic` macro now throws an
`ex-info` when running out of retries, which should make it possible to differentiate between this situation and grosser sorts of Exceptions.
