### PR TITLE
Validate `conn-opts` passed to wcar

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Add the necessary dependency to your [Leiningen][] `project.clj` and `require` t
 You'll usually want to define a single connection pool, and one connection spec for each of your Redis servers.
 
 ```clojure
-(def server1-conn {:pool {<opts>} :spec {<opts>}}) ; See `wcar` docstring for opts
+; (def server1-conn {:pool {<opts>} :spec {<opts>}}) ; See `wcar` docstring for opts
+(def server1-conn {:spec {:host 172.0.0.3 :port 6378}})
 (defmacro wcar* [& body] `(car/wcar server1-conn ~@body))
 ```
 

--- a/src/taoensso/carmine.clj
+++ b/src/taoensso/carmine.clj
@@ -35,6 +35,7 @@
   See also `with-replies`."
   {:arglists '([conn-opts :as-pipeline & body] [conn-opts & body])}
   ;; [conn-opts & [s1 & sn :as sigs]]
+  ;; FIXME: conn-opts should be validated!!!! it's way too easy to mess up!
   [conn-opts & sigs]
   `(let [[pool# conn#] (conns/pooled-conn ~conn-opts)
 


### PR DESCRIPTION
I just spent a considerable amount of time debugging my app because the `conn-opts` I was passing to `wcar` was:
```clojure
{:host "123.123.123.123"}
```
instead of
```clojure
{:spec {:host "123.123.123"}}
```
Now, after rereading the docstring for `wcar` it feels like a very silly mistake. However, I feel like I could have gotten a much better error if I got a message saying that the options I was passing in were malformed.

If I were to implement it, would you be open to merging a PR that validates `conn-opts` with something like [schema](https://github.com/Prismatic/schema)? Any thoughts?