### PR TITLE
Fix NoClassDefFoundError when included in uberjar

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,9 +10,11 @@
   :global-vars {*warn-on-reflection* true
                 *assert* true}
 
+  :aot [taoensso.carmine.connections]
+
   :dependencies
   [[org.clojure/clojure              "1.4.0"]
-   [com.taoensso/encore              "1.23.1"]
+   [com.taoensso/encore              "1.24.1"]
    [com.taoensso/timbre              "3.4.0"]
    [com.taoensso/nippy               "2.8.0"]
    [org.apache.commons/commons-pool2 "2.3"]


### PR DESCRIPTION
I am getting:

```Exception in thread "main" java.lang.NoClassDefFoundError: taoensso/carmine/connections/IConnectionPool```

when starting my application from an uberjar which is build with ```:aot :all```.  This change makes sure the protocol is compiled and included in the jar file.  It probably has something to do with my code using the ```wcar``` macro.

Please note: the version of 1.24.1 does not yet exist.  , I've submitted a pull request because 1.23.1 and the current 1.24.0 version it do not compile: https://github.com/ptaoussanis/encore/pull/14