### PR TITLE
[#113] Parse database number out of redis uri

### DIFF
--- a/src/taoensso/carmine/connections.clj
+++ b/src/taoensso/carmine/connections.clj
@@ -167,10 +167,12 @@
   (when uri
     (let [^URI uri (if (instance? URI uri) uri (URI. uri))
           [user password] (.split (str (.getUserInfo uri)) ":")
-          port (.getPort uri)]
+          port (.getPort uri)
+          db (if-let [db-str (last (re-matches #"/(\d+)" (.getPath uri)))] (Integer. ^String db-str))]
       (-> {:host (.getHost uri)}
-          (#(if (pos? port) (assoc % :port     port)     %))
-          (#(if password    (assoc % :password password) %))))))
+          (#(if (pos? port)        (assoc % :port     port)     %))
+          (#(if (and db (pos? db)) (assoc % :db       db)       %))
+          (#(if password           (assoc % :password password) %))))))
 
 (comment (parse-uri "redis://redistogo:pass@panga.redistogo.com:9475/"))
 


### PR DESCRIPTION
Here is my take on fixing #113.

Currently any information in redis uri path is simply ignored.
Summary of this pull request: if path is a non-default db number, it is extracted and used, otherwise it is ignored.