### PR TITLE
Part work -cluster support

### DIFF
--- a/src/taoensso/carmine.clj
+++ b/src/taoensso/carmine.clj
@@ -53,7 +53,11 @@
            (protocol/execute-requests :get-replies :as-pipeline))]
 
      (try
-       (let [response# (protocol/with-context conn#
+
+       (let [get-conn# (fn [opts#] (conns/get-conn pool# opts#))
+             release-conn# (fn [c#] (conns/release-conn pool# c#))
+             conn2# (assoc conn# :get-conn get-conn# :release-conn release-conn#)
+             response# (protocol/with-context conn2#
                          (protocol/with-replies ~@sigs))]
          (conns/release-conn pool# conn#)
          response#)

--- a/test/taoensso/carmine/tests/cluster.clj
+++ b/test/taoensso/carmine/tests/cluster.clj
@@ -1,0 +1,20 @@
+(ns taoensso.carmine.tests.cluster
+  (:require [taoensso.carmine :as car]
+            [taoensso.carmine.tests.cluster :refer :all]
+            [clojure.test :refer :all]))
+
+
+
+(def conn1 {:pool {} :spec {:host "localhost" :port 8002 :cluster true}})
+(def conn2 {:pool {} :spec {:host "localhost" :port 6379}})
+
+(defmacro wcar1 [& form]
+  `(car/wcar conn1 ~@form))
+
+(defmacro wcar2 [& form]
+  `(car/wcar conn2 ~@form))
+
+(println  (wcar1 (car/get "D")
+                 (car/incr "K")
+                 (car/incr "A")))
+(wcar2 (car/incr "I"))


### PR DESCRIPTION
@ptaoussanis 

This PR is for review only.

I am trying to take a shot at Issue #76 following your comments in cluster.clj.
Not sure if this is on the right track, but a couple of additional things to consider:
1) Keys can move between clusters. This results in a MOVED exception so the operation has to be retried.   before which the exception has to be  parsed and the new slot:server-port mapping is updated in the cache, OR, a separate update request has to be sent to the server to get the new slot-server tables. I think the latter is the recommended approach at redis.io -  since when a slot moves, its likely to be a batch operation and several requests may encounter the error.

2) I didn't quite get how the pooling would work when a MOVED exception is encountered. The connections in the (default) thread pool would be using the original spec. Each MOVED exception, is basically discovering a new spec that has never been seen/declared. So a pool:spec:conn index needs to be maintained I think. 
