### PR TITLE
Expand shortened links for more future-proof comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [com.taoensso/carmine "2.12.2"] ; Stable
 ```
 
+Want to help [support taoensso/open-source]?
+
 # Carmine
 
 ### A Clojure Redis client & message queue
@@ -384,6 +386,7 @@ Copyright &copy; 2012-2016 [Peter Taoussanis].
 [@ptaoussanis]: https://www.taoensso.com
 [More by @ptaoussanis]: https://www.taoensso.com
 [Break Version]: https://github.com/ptaoussanis/encore/blob/master/BREAK-VERSIONING.md
+[support taoensso/open-source]: http://taoensso.com/clojure/backers
 
 <!--- Standard links (repo specific) -->
 [CHANGELOG]: https://github.com/ptaoussanis/carmine/releases

--- a/src/taoensso/carmine.clj
+++ b/src/taoensso/carmine.clj
@@ -33,8 +33,9 @@
 
   A `nil` or `{}` `conn-opts` will use defaults. A `:none` pool can be used
   to skip connection pooling (not recommended).
-  For other pool options, Ref. http://goo.gl/e1p1h3,
-                               http://goo.gl/Sz4uN1 (defaults).
+  For other pool options, Ref.:
+  - https://commons.apache.org/proper/commons-pool/api-2.0/org/apache/commons/pool2/impl/GenericKeyedObjectPool.html
+  - Defaults: https://commons.apache.org/proper/commons-pool/api-2.0/constant-values.html#org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig.DEFAULT_MAX_TOTAL
 
   Note that because of thread-binding, you'll probably want to avoid lazy Redis
   command calls in `wcar`'s body unless you know what you're doing. Compare:
@@ -529,7 +530,9 @@
             (return abort-val)))))))
 
 ;;;; CAS tools (experimental!)
-;; Working around the lack of simple CAS in Redis core, Ref http://goo.gl/M4Phx8
+;; Working around the lack of simple CAS in Redis core, Ref
+;; https://groups.google.com/forum/#!topic/redis-db/a4zK2k1Lefo
+;; ("CAS and why I don't want to add it to Redis")
 
 (defn- prep-cas-old-val [x]
   (let [^bytes bs (protocol/coerce-bs x)

--- a/src/taoensso/carmine.clj
+++ b/src/taoensso/carmine.clj
@@ -699,11 +699,9 @@
 
 (defn hgetall* "DEPRECATED: Use `parse-map` instead."
   [key & [keywordize?]]
-  (let [keywordize-map (fn [m] (reduce-kv (fn [m k v] (assoc m (keyword k) v))
-                                         {} (or m {})))
-        inner-parser (when-let [p protocol/*parser*] #(mapv p %))
+  (let [inner-parser (when-let [p protocol/*parser*] #(mapv p %))
         outer-parser (if keywordize?
-                       #(keywordize-map (apply hash-map %))
+                       #(enc/map-keys keyword (apply hash-map %))
                        #(apply hash-map %))]
     (->> (hgetall key)
          (parse (parser-comp outer-parser inner-parser)))))

--- a/src/taoensso/carmine.clj
+++ b/src/taoensso/carmine.clj
@@ -619,6 +619,24 @@
 
 (comment (enc/qb 100 (wcar {} (swap "swap-k" (fn [?old _] ?old)))))
 
+;;;;
+
+(defn reduce-scan
+  "For use with `scan`, `zscan`, etc. Takes:
+    - (fn rf      [acc scan-result]) -> next accumulator
+    - (fn scan-fn [cursor]) -> next scan result"
+  ([rf          scan-fn] (reduce-scan rf nil scan-fn))
+  ([rf acc-init scan-fn]
+   (loop [cursor "0" acc acc-init]
+     (let [[next-cursor in] (scan-fn cursor)]
+       (if (= next-cursor "0")
+         (rf acc in)
+         (recur next-cursor (rf acc in)))))))
+
+(comment
+  (reduce-scan (fn rf [acc in] (into acc in))
+    [] (fn scan-fn [cursor] (wcar {} (scan cursor)))))
+
 ;;;; Deprecated
 
 (def as-long   "DEPRECATED: Use `as-int` instead."   as-int)

--- a/src/taoensso/carmine.clj
+++ b/src/taoensso/carmine.clj
@@ -414,9 +414,9 @@
 
 (defmacro atomic* "Alpha - subject to change. Low-level transaction util."
   [conn-opts max-cas-attempts on-success on-failure]
-    (assert (>= max-cas-attempts 1))
   `(let [conn-opts#  ~conn-opts
          max-idx#    ~max-cas-attempts
+         _# (assert (>= max-idx# 1))
          prelude-result# (atom nil)
          exec-result#
          (wcar conn-opts# ; Hold 1 conn for all attempts

--- a/src/taoensso/carmine/commands.clj
+++ b/src/taoensso/carmine/commands.clj
@@ -50,7 +50,7 @@
   "Returns the Redis Cluster key slot ℕ∈[0,num-keyslots) for given key arg using
   the CRC16 algorithm, Ref. http://redis.io/topics/cluster-spec Appendix A."
   [x]
-  (enc/cond-throw
+  (enc/cond!
    (enc/bytes? x) (mod (utils/crc16 x) num-keyslots)
    (string?       x)
    (let [;; Hash only *first* '{<part>}' when present + non-empty:

--- a/src/taoensso/carmine/connections.clj
+++ b/src/taoensso/carmine/connections.clj
@@ -29,7 +29,7 @@
   IConnection
   (conn-alive? [this]
     (if (:listener? spec)
-      true ; TODO Waiting on Ref. http://goo.gl/LPhIO
+      true ; TODO Waiting on Ref. https://github.com/antirez/redis/issues/420
       (= "PONG"
         (try
           (protocol/with-context this
@@ -58,7 +58,7 @@
   (let [;; :timeout-ms controls both :conn-timeout-ms and :read-timeout-ms
         ;; unless those are specified individually
         ;; :or   {conn-timeout-ms (or timeout-ms 4000)
-        ;;        read-timeout-ms timeout-ms} ; Ref. http://goo.gl/XULHCd
+        ;;        read-timeout-ms timeout-ms} ; Ref. https://github.com/ptaoussanis/carmine/issues/130
         conn-timeout-ms (get spec :conn-timeout-ms (or timeout-ms 4000))
         read-timeout-ms (get spec :read-timeout-ms     timeout-ms)
 
@@ -147,7 +147,7 @@
            ;; Pass through pre-made pools (note that test reflects):
            (satisfies? IConnectionPool pool-opts) pool-opts
            :else
-           (let [jedis-defaults ; Ref. http://goo.gl/y1mDbE
+           (let [jedis-defaults ; Ref. https://github.com/xetorthio/jedis/blob/master/src/main/java/redis/clients/jedis/JedisPoolConfig.java
                  {:test-while-idle?              true  ; from false
                   :num-tests-per-eviction-run    -1    ; from 3
                   :min-evictable-idle-time-ms    60000 ; from 1800000

--- a/src/taoensso/carmine/locks.clj
+++ b/src/taoensso/carmine/locks.clj
@@ -6,7 +6,8 @@
   Redis keys:
     * carmine:lock:<lock-name> -> ttl str, lock owner's UUID.
 
-  Ref. http://goo.gl/5UalQ for implementation details."
+  Ref. http://www.dr-josiah.com/2012/01/creating-lock-with-redis.html for
+  implementation details."
   (:require [taoensso.timbre  :as timbre]
             [taoensso.carmine :as car :refer (wcar)]))
 
@@ -14,7 +15,8 @@
 
 (defn acquire-lock
   "Attempts to acquire a distributed lock, returning an owner UUID iff successful."
-  ;; TODO Waiting on http://goo.gl/YemR7 for simpler (non-Lua) solution
+  ;; TODO Waiting on https://github.com/antirez/redis/issues/931 for
+  ;; simpler (non-Lua) solution
   [conn-opts lock-name timeout-ms wait-ms]
   (let [max-udt (+ wait-ms (System/currentTimeMillis))
         uuid    (str (java.util.UUID/randomUUID))]

--- a/src/taoensso/carmine/ring.clj
+++ b/src/taoensso/carmine/ring.clj
@@ -1,18 +1,20 @@
 (ns taoensso.carmine.ring
-  "Carmine-backed Ring session store. Adapted from clj-redis-session."
+  "Carmine-backed Ring session store."
   {:author "Peter Taoussanis"}
-  (:require [ring.middleware.session.store :as session-store]
+  (:require [taoensso.encore  :as enc]
             [taoensso.carmine :as car :refer (wcar)]))
 
 (defrecord CarmineSessionStore [conn-opts prefix ttl-secs]
-  session-store/SessionStore
-  (read-session   [_ key] (or (when key (wcar conn-opts (car/get key))) {}))
-  (delete-session [_ key] (wcar conn-opts (car/del key)) nil)
-  (write-session  [_ key data]
-    (let [key (or key (str prefix ":" (java.util.UUID/randomUUID)))]
-      (wcar conn-opts (if ttl-secs (car/setex key ttl-secs data)
-                                   (car/set   key          data)))
-      key)))
+  ring.middleware.session.store/SessionStore
+  (read-session   [_ k] (wcar conn-opts (car/get k)))
+  (delete-session [_ k] (wcar conn-opts (car/del k)) nil)
+  (write-session  [_ k data]
+    (let [k (or k (str prefix ":" (enc/uuid-str)))]
+      (wcar conn-opts
+        (if ttl-secs
+          (car/setex k ttl-secs data)
+          (car/set   k          data)))
+      k)))
 
 (defn carmine-store
   "Creates and returns a Carmine-backed Ring SessionStore. Use `expiration-secs`
@@ -20,8 +22,8 @@
   sessions will never expire."
   [conn-opts & [{:keys [key-prefix expiration-secs]
                  :or   {key-prefix      "carmine:session"
-                        expiration-secs (* 60 60 24 30)}}]]
-  (->CarmineSessionStore conn-opts key-prefix expiration-secs))
+                        expiration-secs (enc/secs :days 30)}}]]
+  (CarmineSessionStore. conn-opts key-prefix expiration-secs))
 
 (defn make-carmine-store ; 1.x backwards compatiblity
   "DEPRECATED. Use `carmine-store` instead."

--- a/src/taoensso/carmine/tundra.clj
+++ b/src/taoensso/carmine/tundra.clj
@@ -1,23 +1,24 @@
 (ns taoensso.carmine.tundra
-  "Semi-automatic datastore layer for Carmine. It's like the magix.
+  "Semi-automatic archival datastore layer for Carmine.
   Use multiple Redis instances (recommended) or Redis databases for local key
   namespacing.
 
   Redis keys:
-    * carmine:tundra:evictable -> set, keys for which `ensure-ks` fetch failure
-                                  should throw an error."
-  {:author "Peter Taoussanis"}
-  (:require [taoensso.nippy         :as nippy]
-            [taoensso.nippy.tools   :as nippy-tools]
-            [taoensso.timbre        :as timbre]
-            [taoensso.encore        :as enc]
-            [taoensso.carmine       :as car :refer (wcar)]
+    * carmine:tundra:evictable - set, ks for which `ensure-ks` fail should throw"
+
+  {:author "Peter Taoussanis (@ptaoussanis)"}
+  (:require [taoensso.encore      :as enc]
+            [taoensso.nippy       :as nippy]
+            [taoensso.nippy.tools :as nippy-tools]
+            [taoensso.timbre      :as timbre]
+            [taoensso.carmine     :as car :refer (wcar)]
             [taoensso.carmine.message-queue :as mq])
   (:import  [java.net URLDecoder URLEncoder]))
 
-;;;; TODO
-;; * Redis 2.8+ http://redis.io/topics/notifications
-;; * Could do with a minor refactor (incl. reduce-based perf, etc.)
+;;;; TODO v2/refactor
+;; - General refactor (reduce-based flow, refactor stores, etc.)
+;; - Drop mq for a simpler zset {<k> <udt-last-dirty>} based model:
+;;   atomic-pull ks on verified write when udt unchanged against write val
 
 ;;;; Public interfaces
 


### PR DESCRIPTION
Links rot at a tremendous rate (maybe 10% per year? higher?) so these
comments should have at least archive.org-compatible links.

In the case of the Google Groups link I included the post title because
the URL appeared particularly unstable.