### PR TITLE
Add qname to argument map passed to queue handler

### DIFF
--- a/src/taoensso/carmine/message_queue.clj
+++ b/src/taoensso/carmine/message_queue.clj
@@ -203,7 +203,8 @@
                     "Error handling %s queue message:\n%s" qname poll-reply))
 
           {:keys [status throwable backoff-ms]}
-          (let [result (try (handler {:mid mid :message mcontent :attempt attempt})
+          (let [result (try (handler {:qname   qname    :mid     mid
+                                      :message mcontent :attempt attempt})
                             (catch Throwable t {:status :error :throwable t}))]
             (when (map? result) result))]
 
@@ -295,7 +296,7 @@
 (defn worker
   "Returns a threaded worker to poll for and handle messages `enqueue`'d to
   named queue. Options:
-   :handler        - (fn [{:keys [mid message attempt]}]) that throws an ex
+   :handler        - (fn [{:keys [qname mid message attempt]}]) that throws an ex
                      or returns {:status     <#{:success :error :retry}>
                                  :throwable  <Throwable>
                                  :backoff-ms <retry-or-dedupe-backoff-ms}.

--- a/test/taoensso/carmine/tests/message_queue.clj
+++ b/test/taoensso/carmine/tests/message_queue.clj
@@ -50,7 +50,7 @@
 
   ;; Handler will *not* run against eoq-backoff/nil reply:
   (is (= nil (mq/handle1 conn-opts tq nil (wcar* (dequeue* tq)))))
-  (is (= {:mid "mid1" :message :msg1, :attempt 1}
+  (is (= {:qname :carmine-test-queue :mid "mid1" :message :msg1, :attempt 1}
         (let [p (promise)]
           (mq/handle1 conn-opts tq #(do (deliver p %) {:status :success})
             (wcar* (dequeue* tq)))
@@ -76,7 +76,7 @@
 (deftest tests-4 ; Handling: retry with backoff
   (is (= "mid1"        (do (clear-tq) (wcar* (mq/enqueue tq :msg1 :mid1)))))
   (is (= "eoq-backoff" (wcar* (dequeue* tq))))
-  (is (= {:mid "mid1" :message :msg1, :attempt 1}
+  (is (= {:qname :carmine-test-queue :mid "mid1" :message :msg1, :attempt 1}
         (let [p (promise)]
           (mq/handle1 conn-opts tq
             #(do (deliver p %) {:status :retry :backoff-ms 3000})
@@ -92,7 +92,7 @@
 (deftest tests-5 ; Handling: success with backoff (dedupe)
   (is (= "mid1"        (do (clear-tq) (wcar* (mq/enqueue tq :msg1 :mid1)))))
   (is (= "eoq-backoff" (wcar* (dequeue* tq))))
-  (is (= {:mid "mid1" :message :msg1, :attempt 1}
+  (is (= {:qname :carmine-test-queue :mid "mid1" :message :msg1, :attempt 1}
         (let [p (promise)]
           (mq/handle1 conn-opts tq
             #(do (deliver p %) {:status :success :backoff-ms 3000})


### PR DESCRIPTION
Pass the `qname` value from the `handle1` context as part of the argument map passed to the `handler` function.

I found that I needed the queue name within the context of a message handler function and had no convenient way to get it. I can work around it a few ways, but I figured I'd see if I could get a PR merged first. :smile: 

This change _should_ be pretty safe to merge: it's backwards compatible, documented, and I've updated the tests to pass with the new return value from `handle1`. If you'd like me to make any additional changes for any reason, just let me know.

Thanks for all you've contributed to the clojure ecosystem @ptaoussanis!