### PR TITLE
Fix protocol/get-parsed-reply fn

### DIFF
--- a/src/taoensso/carmine/protocol.clj
+++ b/src/taoensso/carmine/protocol.clj
@@ -213,7 +213,7 @@
               ;; Nb :parse-exceptions? is rare & not normally used by lib
               ;; consumers. Such parsers need to be written to _not_
               ;; interfere with our ability to interpret Cluster error msgs.
-              (not (get :parse-exceptions? req-opts)))
+              (not (get req-opts :parse-exceptions?)))
 
           unparsed-reply ; Return unparsed
           (try


### PR DESCRIPTION
This bug was introduced in commit -
a2bef0cc56d9eb4de9703894ead05c7822ad860e

By mistake the arguments to get function were swapped, hence 1 test in
taoensso.carmine.tests.main ns have been failing since then.

This fixes it.

Test output:
```
$ lein clean; lein expectations taoensso.carmine.tests.main

Benching (this can take some time)
----------------------------------

Lap 1/1...
{:wcar 43, :ping 447, :set 394, :get 399, :roundtrip 496, :ping-pipelined 2012}

Done! (Time for cake?)

Ran 118 tests containing 118 assertions in 8643 msecs
[32m0 failures, 0 errors[0m.
```