### PR TITLE
Migrate tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,14 +27,10 @@
    :1.8  {:dependencies [[org.clojure/clojure "1.8.0"]]}
    :1.9  {:dependencies [[org.clojure/clojure "1.9.0-alpha10"]]}
    :test {:dependencies [;; 2.1.4 has breaking changes
-                         ;; TODO Migrate expectations->clojure.test
-                         [expectations            "2.1.3"]
                          [org.clojure/test.check  "0.9.0"]
                          [com.taoensso/faraday    "1.9.0"]
                          [clj-aws-s3              "0.3.10"]
-                         [ring/ring-core          "1.5.0"]]
-          :plugins [[lein-expectations "0.0.8"]
-                    [lein-autoexpect   "1.9.0"]]}
+                         [ring/ring-core          "1.5.0"]]}
    :dev
    [:1.9 :test :server-jvm
     {:dependencies [[org.clojure/data.json "0.2.6"]]
@@ -49,8 +45,7 @@
    :source-uri "https://github.com/ptaoussanis/carmine/blob/master/{filepath}#L{line}"}
 
   :aliases
-  {"test-all"   ["with-profile" "+1.9:+1.8:+1.7:+1.6:+1.5" "expectations"]
-   "test-auto"  ["with-profile" "+test" "autoexpect"]
+  {"test-all"   ["with-profile" "+1.9:+1.8:+1.7:+1.6:+1.5" "test"]
    "deploy-lib" ["do" "deploy" "clojars," "install"]
    "start-dev"  ["with-profile" "+dev" "repl" ":headless"]}
 

--- a/test/taoensso/carmine/tests/main.clj
+++ b/test/taoensso/carmine/tests/main.clj
@@ -1,6 +1,6 @@
 (ns taoensso.carmine.tests.main
   (:require [clojure.string :as str]
-            [expectations     :as test :refer :all]
+            [clojure.test :refer :all]
             [taoensso.encore  :as enc]
             [taoensso.carmine :as car  :refer (wcar)]
             [taoensso.carmine.commands   :as commands]
@@ -8,424 +8,532 @@
             [taoensso.carmine.benchmarks :as benchmarks]))
 
 ;; (remove-ns 'taoensso.carmine.tests.main)
-(comment (test/run-tests '[taoensso.carmine.tests.main]))
+(comment (run-tests '[taoensso.carmine.tests.main]))
 
 (defmacro wcar* [& body] `(car/wcar {:pool {} :spec {}} ~@body))
 (def tkey (partial car/key :carmine :temp :test))
 (defn clean-up-tkeys! [] (when-let [ks (seq (wcar* (car/keys (tkey :*))))]
                            (wcar* (apply car/del ks))))
 
-(defn- before-run {:expectations-options :before-run} [] (clean-up-tkeys!))
-(defn- after-run  {:expectations-options :after-run}  [] (clean-up-tkeys!))
+(defn cleanup-fixture
+  [f]
+  (clean-up-tkeys!)
+  (f)
+  (clean-up-tkeys!))
 
-;;;; Migrated
+(use-fixtures :once cleanup-fixture)
 
-(expect "Message" (wcar* (car/echo "Message")))
-(expect "PONG"    (wcar* (car/ping)))
 
-(let [k (tkey "exists")]
-  (expect 0     (wcar* (car/exists k)))
-  (expect 1 (do (wcar* (car/set    k "exists!"))
-                (wcar* (car/exists k)))))
+(deftest basic-tests
+  (is (= "Message" (wcar* (car/echo "Message"))))
+  (is (= "PONG" (wcar* (car/ping)))))
 
-(let [k (tkey "server:name")]
-  (expect "OK"   (wcar* (car/set k "fido")))
-  (expect "fido" (wcar* (car/get k)))
-  (expect 15     (wcar* (car/append k " [shutdown]")))
-  (expect "fido [shutdown]" (wcar* (car/getset   k "fido [running]")))
-  (expect "running"         (wcar* (car/getrange k 6 12))))
 
-(let [k (tkey "mykey")]
-  (expect 1 (do (wcar* (car/setbit k 7 1))
-                (wcar* (car/getbit k 7)))))
+(deftest key-exists-test
+  (let [k (tkey "exists")]
+    (is (= 0 (wcar* (car/exists k)))
+        "Since key does not exists should return 0")
 
-(let [k (tkey "multiline")]
-  (expect "OK" (wcar* (car/set k "Redis\r\nDemo")))
-  (expect "Redis\r\nDemo" (wcar* (car/get k))))
+    ;; Set key
+    (wcar* (car/set k "exists!"))
+    (is (= 1 (wcar* (car/exists k)))
+        "Now that key is set, it should exists!")))
 
-(let [k (tkey "connections")]
-  (expect 11 (do (wcar* (car/set k 10))
-                 (wcar* (car/incr k))))
-  (expect 20 (wcar* (car/incrby k 9)))
-  (expect 19 (wcar* (car/decr k)))
-  (expect 10 (wcar* (car/decrby k 9))))
 
-(let [k (tkey "something")]
-  (expect 1 (do (wcar* (car/set k "foo"))
-                (wcar* (car/del k)))))
+(deftest getset-test
+  (let [k (tkey "server:name")]
+    (is (= "OK"              (wcar* (car/set k "fido"))))
+    (is (= "fido"            (wcar* (car/get k))))
+    (is (= 15                (wcar* (car/append k " [shutdown]"))))
+    (is (= "fido [shutdown]" (wcar* (car/getset k "fido [running]"))))
+    (is (= "running"         (wcar* (car/getrange k 6 12))))))
 
-(let [k (tkey "resource:lock")]
-  (expect -1 (do (wcar* (car/set k "Redis Demo"))
-                 (wcar* (car/ttl k))))
-  (expect 1 (wcar* (car/expire k 120)))
-  (expect #(< 0 %) (wcar* (car/ttl k))))
 
-(let [k (tkey "friends")]
-  (expect ["Sam" "Tom" "Bob"]
-    (do (wcar* (car/rpush k "Tom"))
-        (wcar* (car/rpush k "Bob"))
-        (wcar* (car/lpush k "Sam"))
-        (wcar* (car/lrange k 0 -1))))
-  (expect ["Sam" "Tom"] (wcar* (car/lrange k 0 1)))
-  (expect ["Sam" "Tom" "Bob"] (wcar* (car/lrange k 0 2)))
-  (expect 3 (wcar* (car/llen k)))
-  (expect "Sam" (wcar* (car/lpop k)))
-  (expect "Bob" (wcar* (car/rpop k)))
-  (expect 1 (wcar* (car/llen k)))
-  (expect ["Tom"] (wcar* (car/lrange k 0 -1))))
 
-(let [k (tkey "spanish")]
-  (expect ["OK" "year->año"] (wcar* (car/set k "year->año")
-                                    (car/get k))))
+(deftest setbit-test
+  (let [k (tkey "mykey")]
+    (wcar* (car/setbit k 7 1))
+    (is (= 1 (wcar* (car/getbit k 7)))
+        "7th bit of the key was set to 1")))
 
-(let [k (tkey "str-field")]
-  (expect Exception (do (wcar* (car/set k "str-value"))
-                        (wcar* (car/incr k))))
-  (expect (some #(instance? Exception %)
-            (wcar* (car/ping) (car/incr k) (car/ping)))))
 
-(expect nil (wcar* "This is a malformed request"))
-(expect "PONG" (wcar* (car/ping) "This is a malformed request"))
-(expect ["PONG" "PONG" "PONG"] (wcar* (doall (repeatedly 3 car/ping))))
-(expect ["A" "B" "C"] (wcar* (doall (map car/echo ["A" "B" "C"]))))
+(deftest multiline-test
+  (let [k (tkey "multiline")]
+    (is (= "OK" (wcar* (car/set k "Redis\r\nDemo"))))
+    (is (= "Redis\r\nDemo" (wcar* (car/get k))))))
 
-(let [out-k (tkey "outside-key")
-      in-k  (tkey "inside-key")]
-  (expect "inside value"
-    (do (wcar* (car/set in-k  "inside value")
-               (car/set out-k in-k))
-        (wcar* (car/get (last (wcar* (car/ping) (car/get out-k))))))))
 
-(let [k (tkey "parallel-key")]
-  (expect "10000"
-    (do (wcar* (car/set k 0))
-        (->> (fn [] (future (dotimes [n 100] (wcar* (car/incr k)))))
-             (repeatedly 100) ; No. of parallel clients
-             (doall)
-             (map deref)
-             (dorun))
-        (wcar* (car/get k)))))
+(deftest inc-dec-tests
+  (let [k (tkey "connections")]
+    (wcar* (car/set k 10))
+    (is (= 11 (wcar* (car/incr k))))
+    (is (= 20 (wcar* (car/incrby k 9))))
+    (is (= 19 (wcar* (car/decr k))))
+    (is (= 10 (wcar* (car/decrby k 9))))))
 
-(let [k (tkey "myhash")]
-  (expect "value1" (do (wcar* (car/hset k "field1" "value1"))
-                       (wcar* (car/hget k "field1"))))
-  (expect "value1" (do (wcar* (car/hsetnx k "field1" "newvalue"))
-                       (wcar* (car/hget k "field1"))))
-  (expect 1 (wcar* (car/hexists k "field1")))
-  (expect ["field1" "value1"] (wcar* (car/hgetall k)))
-  (expect 3 (do (wcar* (car/hset k "field2" 1))
-                (wcar* (car/hincrby k "field2" 2))))
-  (expect ["field1" "field2"] (wcar* (car/hkeys k)))
-  (expect ["value1" "3"] (wcar* (car/hvals k)))
-  (expect 2 (wcar* (car/hlen k)))
-  (expect 0 (do (wcar* (car/hdel k "field1"))
-                (wcar* (car/hexists k "field1")))))
 
-(let [k1 (tkey "superpowers")
-      k2 (tkey "birdpowers")]
-  (expect 1 (do (wcar* (car/sadd k1 "flight"))
-                (wcar* (car/sadd k1 "x-ray vision"))
-                (wcar* (car/sadd k1 "reflexes"))
-                (wcar* (car/srem k1 "reflexes"))
-                (wcar* (car/sismember k1 "flight"))))
-  (expect 0 (wcar* (car/sismember k1 "reflexes")))
-  (expect (set ["flight" "pecking" "x-ray vision"])
-    (do (wcar* (car/sadd k2 "pecking"))
-        (wcar* (car/sadd k2 "flight"))
-        (set (wcar* (car/sunion k1 k2))))))
+(deftest delete-key-test
+  (let [k (tkey "something")]
+    (wcar* (car/set k "foo"))
+    (is (= 1 (wcar* (car/del k))))))
 
-(let [k1 (tkey "hackers")
-      k2 (tkey "slackers")
-      k1-U-k2 (tkey "hackersnslackers")
-      k1-I-k2 (tkey "hackerslackers")]
-  (expect ["Alan Kay" "Richard Stallman" "Yukihiro Matsumoto"]
-    (do
-      (wcar*
-        (car/zadd k1 "1940" "Alan Kay")
-        (car/zadd k1 "1953" "Richard Stallman")
-        (car/zadd k1 "1965" "Yukihiro Matsumoto")
-        (car/zadd k1 "1916" "Claude Shannon")
-        (car/zadd k1 "1969" "Linus Torvalds")
-        (car/zadd k1 "1912" "Alan Turing")
-        (car/zadd k1 "1972" "Dade Murphy")
-        (car/zadd k1 "1970" "Emmanuel Goldstein")
-        (car/zadd k2 "1968" "Pauly Shore")
-        (car/zadd k2 "1972" "Dade Murphy")
-        (car/zadd k2 "1970" "Emmanuel Goldstein")
-        (car/zadd k2 "1966" "Adam Sandler")
-        (car/zadd k2 "1962" "Ferris Beuler")
-        (car/zadd k2 "1871" "Theodore Dreiser")
-        (car/zunionstore* k1-U-k2 [k1 k2])
-        (car/zinterstore* k1-I-k2 [k1 k2]))
-      (wcar* (car/zrange k1 2 4))))
-  (expect ["Claude Shannon" "Alan Kay" "Richard Stallman" "Ferris Beuler"]
-    (wcar* (car/zrange k1-U-k2 2 5)))
-  (expect ["Emmanuel Goldstein" "Dade Murphy"]
-    (wcar* (car/zrange k1-I-k2 0 1))))
 
-(let [k1 (tkey "children")
-      k2 (tkey "favorite:child")]
-  (expect ["B" "B"] (do (wcar* (car/rpush k1 "A")
-                               (car/rpush k1 "B")
-                               (car/rpush k1 "C")
-                               (car/set   k2 "B"))
-                        (wcar* (car/get k2)
-                               (car/get k2))))
-  (expect ["B" ["A" "B" "C"] "B"]
-    (wcar* (car/get k2)
-           (car/lrange k1 0 3)
-           (car/get k2))))
+(deftest expiry-tests
+  (let [k (tkey "resource:lock")]
+    (wcar* (car/set k "Redis Demo"))
+    (is (= -1 (wcar* (car/ttl k))))
+    (is (= 1  (wcar* (car/expire k 120))))
+    (is (pos? (wcar* (car/ttl k))))))
+
+
+(deftest array-cmds-tests
+  (let [k (tkey "friends")]
+    (testing "Push command"
+      (wcar* (car/rpush k "Tom"))
+      (wcar* (car/rpush k "Bob"))
+      (wcar* (car/lpush k "Sam"))
+      (is (= ["Sam" "Tom" "Bob"]
+             (wcar* (car/lrange k 0 -1)))))
+
+    (testing "lrange command"
+      (is (= ["Sam" "Tom"]       (wcar* (car/lrange k 0 1))))
+      (is (= ["Sam" "Tom" "Bob"] (wcar* (car/lrange k 0 2)))))
+
+    (testing "len and pop commands"
+      (is (= 3       (wcar* (car/llen k))))
+      (is (= "Sam"   (wcar* (car/lpop k))))
+      (is (= "Bob"   (wcar* (car/rpop k))))
+      (is (= 1       (wcar* (car/llen k))))
+      (is (= ["Tom"] (wcar* (car/lrange k 0 -1)))))))
+
+
+(deftest get-set-spanish-test
+  (let [k (tkey "spanish")]
+    (is (= ["OK" "year->año"]
+           (wcar* (car/set k "year->año") (car/get k))))))
+
+
+(deftest exception-test
+  (let [k (tkey "str-field")]
+
+    (wcar* (car/set k "str-value"))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (wcar* (car/incr k)))
+        "Can't increment a string value")
+
+    (let [[r1 r2 r3] (wcar* (car/ping)
+                            (car/incr k)
+                            (car/ping))]
+      (is (= "PONG" r1))
+      (is (instance? clojure.lang.ExceptionInfo r2))
+      (is (= "PONG" r3)))))
+
+
+(deftest malformed-tests
+  (is (= nil (wcar* "This is a malformed request")))
+  (is (= "PONG" (wcar* (car/ping) "This is a malformed request"))))
+
+
+(deftest pong-test
+  (is (= ["PONG" "PONG" "PONG"]
+         (wcar* (doall (repeatedly 3 car/ping))))))
+
+
+(deftest echo-test
+  (is (= ["A" "B" "C"]
+         (wcar* (doall (map car/echo ["A" "B" "C"]))))))
+
+
+(deftest key-inside-key-test
+  (let [out-k (tkey "outside-key")
+        in-k  (tkey "inside-key")]
+    (wcar* (car/set in-k "inside value")
+           (car/set out-k in-k))
+    (is (= "inside value"
+           (wcar* (car/get (last (wcar* (car/ping)
+                                        (car/get out-k))))))
+        "Should get the inner value")))
+
+
+(deftest parallel-incr-test
+  (let [k (tkey "parallel-key")]
+    (wcar* (car/set k 0))
+    (->> (fn [] (future (dotimes [n 100] (wcar* (car/incr k)))))
+         (repeatedly 100)   ; No. of parallel clients
+         (doall)
+         (map deref)
+         (dorun))
+    (is (= "10000"
+           (wcar* (car/get k))))))
+
+(deftest hash-set-test
+  (let [k (tkey "myhash")]
+
+    (wcar* (car/hset k "field1" "value1"))
+    (is (= "value1" (wcar* (car/hget k "field1"))))
+
+    (wcar* (car/hsetnx k "field1" "newvalue"))
+    (is (= "value1" (wcar* (car/hget k "field1"))))
+
+    (is (= 1 (wcar* (car/hexists k "field1"))))
+
+    (is (= ["field1" "value1"] (wcar* (car/hgetall k))))
+
+    (wcar* (car/hset k "field2" 1))
+    (is (= 3 (wcar* (car/hincrby k "field2" 2))))
+
+    (is (= ["field1" "field2"] (wcar* (car/hkeys k))))
+
+    (is (= ["value1" "3"] (wcar* (car/hvals k))))
+
+    (is (= 2 (wcar* (car/hlen k))))
+
+    (wcar* (car/hdel k "field1"))
+    (is (= 0 (wcar* (car/hexists k "field1"))))))
+
+
+(deftest set-tests
+  (let [k1 (tkey "superpowers")
+        k2 (tkey "birdpowers")]
+
+    (testing "Member in set case"
+      (wcar* (car/sadd k1 "flight"))
+      (wcar* (car/sadd k1 "x-ray vision"))
+      (wcar* (car/sadd k1 "reflexes"))
+      (wcar* (car/srem k1 "reflexes"))
+      (is 1 (= (wcar* (car/sismember k1 "flight")))))
+
+    (testing "Member NOT in set case"
+      (is (= 0 (wcar* (car/sismember k1 "reflexes")))))
+
+    (testing "Set union case"
+      (wcar* (car/sadd k2 "pecking"))
+      (wcar* (car/sadd k2 "flight"))
+      (is (= (set ["flight" "pecking" "x-ray vision"])
+             (set (wcar* (car/sunion k1 k2))))))))
+
+(deftest sorted-set-tests
+  (let [k1 (tkey "hackers")
+        k2 (tkey "slackers")
+        k1-U-k2 (tkey "hackersnslackers")
+        k1-I-k2 (tkey "hackerslackers")]
+
+    (testing "Sorted Set case 1"
+      (wcar* (car/zadd k1 "1940" "Alan Kay")
+             (car/zadd k1 "1953" "Richard Stallman")
+             (car/zadd k1 "1965" "Yukihiro Matsumoto")
+             (car/zadd k1 "1916" "Claude Shannon")
+             (car/zadd k1 "1969" "Linus Torvalds")
+             (car/zadd k1 "1912" "Alan Turing")
+             (car/zadd k1 "1972" "Dade Murphy")
+             (car/zadd k1 "1970" "Emmanuel Goldstein")
+             (car/zadd k2 "1968" "Pauly Shore")
+             (car/zadd k2 "1972" "Dade Murphy")
+             (car/zadd k2 "1970" "Emmanuel Goldstein")
+             (car/zadd k2 "1966" "Adam Sandler")
+             (car/zadd k2 "1962" "Ferris Beuler")
+             (car/zadd k2 "1871" "Theodore Dreiser")
+             (car/zunionstore* k1-U-k2 [k1 k2])
+             (car/zinterstore* k1-I-k2 [k1 k2]))
+      (is (= ["Alan Kay" "Richard Stallman" "Yukihiro Matsumoto"]
+             (wcar* (car/zrange k1 2 4)))))
+
+    (testing "Sorted Set Union Case"
+      (is (= ["Claude Shannon" "Alan Kay" "Richard Stallman" "Ferris Beuler"]
+             (wcar* (car/zrange k1-U-k2 2 5)))))
+
+    (testing "Sorted Set Intersect Case"
+      (is (= ["Emmanuel Goldstein" "Dade Murphy"]
+             (wcar* (car/zrange k1-I-k2 0 1)))))))
+
+(deftest getset-test-2
+  (let [k1 (tkey "children")
+        k2 (tkey "favorite:child")]
+
+    (testing "Case 1"
+      (wcar* (car/rpush k1 "A")
+             (car/rpush k1 "B")
+             (car/rpush k1 "C")
+             (car/set   k2 "B"))
+      (is (= ["B" "B"] (wcar* (car/get k2)
+                              (car/get k2)))))
+
+    (testing "Case 2"
+      (is (= ["B" ["A" "B" "C"] "B"]
+             (wcar* (car/get k2)
+                    (car/lrange k1 0 3)
+                    (car/get k2)))))))
 
 ;;; Pub/sub
 
-(expect-let
-  [received (atom [])
-   listener (car/with-new-pubsub-listener
-              {} {"ps-foo" #(swap! received conj %)}
-              (car/subscribe "ps-foo"))]
-  [["subscribe" "ps-foo" 1]
-   ["message"   "ps-foo" "one"]
-   ["message"   "ps-foo" "two"]
-   ["message"   "ps-foo" "three"]]
-  (do
+(deftest pubsub-single-channel-test
+  (let [received (atom [])
+        listener (car/with-new-pubsub-listener
+                   {} {"ps-foo" #(swap! received conj %)}
+                   (car/subscribe "ps-foo"))]
     (wcar* (car/publish "ps-foo" "one")
            (car/publish "ps-foo" "two")
            (car/publish "ps-foo" "three"))
     (Thread/sleep 500)
     (car/close-listener listener)
-    @received))
+    (is (= [["subscribe" "ps-foo" 1]
+            ["message"   "ps-foo" "one"]
+            ["message"   "ps-foo" "two"]
+            ["message"   "ps-foo" "three"]]
+           @received))))
 
-(expect-let
-  [received (atom [])
-   listener (car/with-new-pubsub-listener
-              {} {"ps-foo" #(swap! received conj %)
-                  "ps-baz" #(swap! received conj %)}
-              (car/subscribe "ps-foo" "ps-baz"))]
-  [["subscribe" "ps-foo" 1]
-   ["subscribe" "ps-baz" 2]
-   ["message"   "ps-foo" "one"]
-   ["message"   "ps-baz" "three"]]
-  (do
+(deftest pubsub-multi-channels-test
+  (let [received (atom [])
+        listener (car/with-new-pubsub-listener
+                   {} {"ps-foo" #(swap! received conj %)
+                       "ps-baz" #(swap! received conj %)}
+                   (car/subscribe "ps-foo" "ps-baz"))]
     (wcar* (car/publish "ps-foo" "one")
            (car/publish "ps-bar" "two")
            (car/publish "ps-baz" "three"))
     (Thread/sleep 500)
     (car/close-listener listener)
-    @received))
+    (is (= [["subscribe" "ps-foo" 1]
+            ["subscribe" "ps-baz" 2]
+            ["message"   "ps-foo" "one"]
+            ["message"   "ps-baz" "three"]]
+           @received))))
 
-(expect-let
-  [received (atom [])
-   listener (car/with-new-pubsub-listener
-              {} {"ps-*"   #(swap! received conj %)
-                  "ps-foo" #(swap! received conj %)})]
-  [["psubscribe"  "ps-*"   1]
-   ["subscribe"   "ps-foo" 2]
-   ["message"     "ps-foo" "one"]
-   ["pmessage"    "ps-*"   "ps-foo" "one"]
-   ["pmessage"    "ps-*"   "ps-bar" "two"]
-   ["pmessage"    "ps-*"   "ps-baz" "three"]
-   ["unsubscribe" "ps-foo" 1]
-   ["pmessage"    "ps-*"   "ps-foo" "four"]
-   ["pmessage"    "ps-*"   "ps-baz" "five"]]
-  (do
+(deftest pubsub-unsubscribe-test
+  (let [received (atom [])
+        listener (car/with-new-pubsub-listener
+                   {} {"ps-*"   #(swap! received conj %)
+                       "ps-foo" #(swap! received conj %)})]
+
     (car/with-open-listener listener
       (car/psubscribe "ps-*")
       (car/subscribe  "ps-foo"))
     (wcar* (car/publish "ps-foo" "one")
            (car/publish "ps-bar" "two")
            (car/publish "ps-baz" "three"))
+
     (Thread/sleep 500)
     (car/with-open-listener listener
       (car/unsubscribe "ps-foo"))
+
     (Thread/sleep 500)
     (wcar* (car/publish "ps-foo" "four")
            (car/publish "ps-baz" "five"))
+
     (Thread/sleep 500)
     (car/close-listener listener)
-    @received))
 
-;;; Bin safety
+    (is (= [["psubscribe"  "ps-*"   1]
+            ["subscribe"   "ps-foo" 2]
+            ["message"     "ps-foo" "one"]
+            ["pmessage"    "ps-*"   "ps-foo" "one"]
+            ["pmessage"    "ps-*"   "ps-bar" "two"]
+            ["pmessage"    "ps-*"   "ps-baz" "three"]
+            ["unsubscribe" "ps-foo" 1]
+            ["pmessage"    "ps-*"   "ps-foo" "four"]
+            ["pmessage"    "ps-*"   "ps-baz" "five"]]
+           @received))))
 
-(let [k  (tkey "binary-safety")
-      ba (byte-array [(byte 3) (byte 1) (byte 4)])]
-  (expect #(enc/ba= ba %) (do (wcar* (car/set k ba))
+
+(deftest bin-safety-test
+  (let [k  (tkey "binary-safety")
+        ba (byte-array [(byte 3) (byte 1) (byte 4)])]
+    (wcar* (car/set k ba))
+    (is (enc/ba= ba (wcar* (car/get k))))))
+
+
+(deftest null-tests
+  (let [k (tkey "nulls")]
+    (is (= nil (do (wcar* (car/set k nil))
+                   (wcar* (car/get k)))))
+    (is (= "" (do (wcar* (car/set k ""))
+                  (wcar* (car/get k)))))
+    (is (= " " (do (wcar* (car/set k " "))
+                   (wcar* (car/get k)))))
+    (is (= 0 (do (wcar* (car/set k (byte-array 0)))
+                 (count (wcar* (car/get k))))))
+    (is (= 1 (do (wcar* (car/set k (.getBytes "\u0000" "UTF-8")))
+                 (count (wcar* (car/get k))))))
+    (is (= "Foobar\u0000" (do (wcar* (car/set k "Foobar\u0000"))
                               (wcar* (car/get k)))))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (wcar* (car/set k "\u0000Foobar"))))))
 
-;;; Nulls
 
-(let [k (tkey "nulls")]
-  (expect nil (do (wcar* (car/set k nil))
-                  (wcar* (car/get k))))
-  (expect "" (do (wcar* (car/set k ""))
-                 (wcar* (car/get k))))
-  (expect " " (do (wcar* (car/set k " "))
-                  (wcar* (car/get k))))
-  (expect 0 (do (wcar* (car/set k (byte-array 0)))
-                (count (wcar* (car/get k)))))
-  (expect 1 (do (wcar* (car/set k (.getBytes "\u0000" "UTF-8")))
-                (count (wcar* (car/get k)))))
-  (expect "Foobar\u0000" (do (wcar* (car/set k "Foobar\u0000"))
-                             (wcar* (car/get k))))
-  (expect Exception (wcar* (car/set k "\u0000Foobar"))))
+(deftest big-response-test
+  (let [k (tkey "big-list")
+        n 250000]
+    (wcar* (dorun (repeatedly n #(car/rpush k "value"))))
+    (is (= (repeat n "value")
+           (wcar* (car/lrange k 0 -1))))))
 
-;;; Big responses
 
-(let [k (tkey "big-list")
-      n 250000]
-  (expect (repeat n "value")
-    (do (wcar* (dorun (repeatedly n (fn [] (car/rpush k "value")))))
-        (wcar* (car/lrange k 0 -1)))))
+(deftest lua-test
+  (let [k (tkey "script")
+        script "return redis.call('set',KEYS[1],'script-value')"
+        script-hash (car/script-hash script)]
 
-;;; Lua
+    (testing "Case 1"
+      (wcar* (car/script-load script))
+      (wcar* (car/evalsha script-hash 1 k))
+      (is (= "script-value" (wcar* (car/get k)))))
 
-(let [k (tkey "script")
-      script "return redis.call('set',KEYS[1],'script-value')"
-      script-hash (car/script-hash script)]
-  (expect "script-value" (do (wcar* (car/script-load script))
-                             (wcar* (car/evalsha script-hash 1 k))
-                             (wcar* (car/get k))))
-  (expect ["key1" "key2" "arg1" "arg2"]
-    (wcar* (car/eval "return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}"
-             2 "key1" "key2" "arg1" "arg2"))))
+    (testing "Case 2"
+      (is (= ["key1" "key2" "arg1" "arg2"]
+             (wcar* (car/eval "return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}"
+                              2 "key1" "key2" "arg1" "arg2")))))))
 
-;;; Reply parsing
 
-(let [k (tkey "reply-parsing")]
-  (expect ["PONG" {:a :A :b :B :c :C :d :D} "pong" "pong" "PONG"]
-    (do
-      (wcar* (car/set k [:a :A :b :B :c :C :d :D]))
-      (wcar* (car/ping)
-             (car/parse #(apply hash-map %) (car/get k))
-             (car/parse str/lower-case
-               (car/ping)
-               (car/ping))
-             (car/ping)))))
+(deftest reply-parsing-test
+  (let [k (tkey "reply-parsing")]
+    (wcar* (car/set k [:a :A :b :B :c :C :d :D]))
+    (is (= ["PONG" {:a :A :b :B :c :C :d :D} "pong" "pong" "PONG"]
+           (wcar* (car/ping)
+                  (car/parse #(apply hash-map %) (car/get k))
+                  (car/parse str/lower-case
+                             (car/ping)
+                             (car/ping))
+                  (car/ping))))))
 
-;;; DEPRECATED `atomically` transactions
 
-(enc/deprecated
-  (let [k      (tkey "atomic")
-        wk     (tkey "watch")
-        k-val  "initial-k-value"
-        wk-val "initial-wk-value"]
+(deftest deprecated-atomically-transactions-tests
+  (enc/deprecated
+   (let [k      (tkey "atomic")
+         wk     (tkey "watch")
+         k-val  "initial-k-value"
+         wk-val "initial-wk-value"]
 
-  ;;; This transaction will succeed
-    (expect ["PONG" "OK"]
-      (do (wcar* (car/set k  k-val)
-            (car/set wk wk-val))
-          (wcar* (car/atomically []
-                   (let [wk-val (wcar* (car/get wk))]
-                     (car/ping)
-                     (car/set k wk-val))))))
+     (testing "This transaction will succeed"
+       (wcar* (car/set k  k-val)
+              (car/set wk wk-val))
+       (is (= ["PONG" "OK"]
+              (wcar* (car/atomically []
+                                     (let [wk-val (wcar* (car/get wk))]
+                                       (car/ping)
+                                       (car/set k wk-val))))))
 
-    (expect wk-val (wcar* (car/get k)))
+       (is (= wk-val (wcar* (car/get k)))))
 
-  ;;; This transaction will fail
-    (expect nil ; []
-      (do (wcar* (car/set k  k-val)
-            (car/set wk wk-val))
-          (wcar* (car/atomically [wk]
-                   (wcar* (car/set wk "CHANGE!")) ; Will break watch
-                   (car/ping)))))
-    (expect k-val (wcar* (car/get k)))))
+     (testing "This transaction will fail"
+       (wcar* (car/set k  k-val)
+              (car/set wk wk-val)))
+     (is (= nil
+            (wcar* (car/atomically [wk]
+                                   ;; Will break watch
+                                   (wcar* (car/set wk "CHANGE!"))
+                                   (car/ping)))))
+     (is (= k-val (wcar* (car/get k)))))))
 
-;;;; with-replies
 
-(expect ["1" "2" ["3" "4"] "5"]
-  (wcar {}
-    (car/echo 1)
-    (car/echo 2)
-    (car/return (car/with-replies (car/echo 3) (car/echo 4)))
-    (car/echo 5)))
+(deftest with-replies-tests
+  (testing "Basic Case"
+    (is (= ["1" "2" ["3" "4"] "5"]
+           (wcar {}
+                 (car/echo 1)
+                 (car/echo 2)
+                 (car/return (car/with-replies (car/echo 3) (car/echo 4)))
+                 (car/echo 5)))))
 
-(expect ["1" "2" ["3" "4" ["5" "6"]] "7"] ; Nested `with-replies`
-  (wcar {}
-    (car/echo 1)
-    (car/echo 2)
-    (car/return (car/with-replies (car/echo 3) (car/echo 4)
-                  (car/return (car/with-replies (car/echo 5) (car/echo 6)))))
-    (car/echo 7)))
+  (testing "Nested 'with-replies' case"
+    (is (= ["1" "2" ["3" "4" ["5" "6"]] "7"]
+           (wcar {}
+                 (car/echo 1)
+                 (car/echo 2)
+                 (car/return (car/with-replies (car/echo 3) (car/echo 4)
+                               (car/return (car/with-replies (car/echo 5) (car/echo 6)))))
+                 (car/echo 7)))))
 
-(expect ["A" "b" ["c" "D"] ["E" "F"] "g"] ; `with-replies` vs parsers
-  (wcar {}
-    (car/parse str/upper-case (car/echo :a))
-    (car/echo :b)
-    (car/return (car/with-replies (car/echo :c) (car/parse str/upper-case (car/echo :d))))
-    (car/return
-      (car/parse str/upper-case
-        (car/with-replies (car/echo :e) (car/echo :f))))
-    (car/echo :g)))
+  (testing "'with-replies' vs parsers case"
+    (is (= ["A" "b" ["c" "D"] ["E" "F"] "g"]
+           (wcar {}
+                 (car/parse str/upper-case (car/echo :a))
+                 (car/echo :b)
+                 (car/return (car/with-replies (car/echo :c) (car/parse str/upper-case (car/echo :d))))
+                 (car/return
+                  (car/parse str/upper-case
+                             (car/with-replies (car/echo :e) (car/echo :f))))
+                 (car/echo :g)))))
 
-(expect ["a" "b" ["c" "d" ["e" "f"]] "g"] ; Nested `with-replies` vs parsers
-  (wcar {}
-    (car/echo :a)
-    (car/echo :b)
-    (car/return
-      (car/parse #(cond (string? %) (str/lower-case %)
-                        (vector? %) (mapv str/lower-case %))
-        (car/with-replies (car/echo :c) (car/echo :d)
-          (car/return (car/parse str/upper-case
-                        (car/with-replies (car/echo :e) (car/echo :f)))))))
-    (car/echo :g)))
+  (testing "Nested 'with-replies' vs parsers case"
+    (is (= ["a" "b" ["c" "d" ["e" "f"]] "g"]
+           (wcar {}
+                 (car/echo :a)
+                 (car/echo :b)
+                 (car/return
+                  (car/parse #(cond (string? %) (str/lower-case %)
+                                    (vector? %) (mapv str/lower-case %))
+                             (car/with-replies (car/echo :c) (car/echo :d)
+                               (car/return (car/parse str/upper-case
+                                                      (car/with-replies (car/echo :e) (car/echo :f)))))))
+                 (car/echo :g))))))
 
 ;;;; Parsers
 ;; Like middleware, comp order can get confusing
 
-;; Basic parsing
-(expect ["PONG" "pong" "pong" "PONG"]
-  (wcar {} (car/ping) (car/parse str/lower-case (car/ping) (car/ping)) (car/ping)))
+(deftest parsers-tests
+  (testing "Basic parsing"
+    (is (= ["PONG" "pong" "pong" "PONG"]
+           (wcar {} (car/ping) (car/parse str/lower-case
+                                          (car/ping)
+                                          (car/ping))
+                 (car/ping)))))
 
-;; Cancel parsing
-(expect "YoLo" (wcar {} (->> (car/echo "YoLo")
-                             (car/parse nil)
-                             (car/parse str/upper-case))))
+  (testing "Cancel parsing"
+    (is (= "YoLo" (wcar {} (->> (car/echo "YoLo")
+                                (car/parse nil)
+                                (car/parse str/upper-case))))))
 
-;; No auto-composition: last-applied (inner) parser wins
-(expect "yolo" (wcar {} (->> (car/echo "YoLo")
-                             (car/parse str/lower-case)
-                             (car/parse str/upper-case))))
+  (testing "No auto-composition: last-applied (inner) parser wins"
+    (is (= "yolo" (wcar {} (->> (car/echo "YoLo")
+                                (car/parse str/lower-case)
+                                (car/parse str/upper-case))))))
 
-;; Dynamic composition: prefer inner
-(expect "yolo" (wcar {} (->> (car/echo "YoLo")
-                             (car/parse (car/parser-comp str/lower-case
-                                                         protocol/*parser*))
-                             (car/parse str/upper-case))))
+  (testing "Dynamic composition: prefer inner"
+    (is (= "yolo" (wcar {} (->> (car/echo "YoLo")
+                                (car/parse (car/parser-comp str/lower-case
+                                                            protocol/*parser*))
+                                (car/parse str/upper-case))))))
 
-;; Dynamic composition: prefer outer
-(expect "YOLO" (wcar {} (->> (car/echo "YoLo")
-                             (car/parse (car/parser-comp protocol/*parser*
-                                                         str/lower-case))
-                             (car/parse str/upper-case))))
+  (testing "Dynamic composition: prefer outer"
+    (is (= "YOLO" (wcar {} (->> (car/echo "YoLo")
+                                (car/parse (car/parser-comp protocol/*parser*
+                                                            str/lower-case))
+                                (car/parse str/upper-case))))))
 
-;; Dynamic composition with metadata (`return` uses metadata and auto-composes)
-(expect "yolo" (wcar {} (->> (car/return "YoLo") (car/parse str/lower-case ))))
+  (testing "Dynamic composition with metadata ('return' uses metadata and auto-composes)"
+    (is (= "yolo" (wcar {} (->> (car/return "YoLo")
+                                (car/parse str/lower-case ))))))
 
-;;; Exceptions pass through by default
-(expect Exception (wcar {} (->> (car/return (Exception. "boo")) (car/parse keyword))))
-(expect vector?   (wcar {} (->> (do (car/return (Exception. "boo"))
-                                    (car/return (Exception. "boo")))
-                                (car/parse keyword))))
+  (testing "Exceptions pass through by default"
+    (is (thrown? Exception (wcar {} (->> (car/return (Exception. "boo")) (car/parse keyword)))))
+    (is (vector? (wcar {} (->> (do (car/return (Exception. "boo"))
+                                   (car/return (Exception. "boo")))
+                               (car/parse keyword))))))
 
-;; Parsers can elect to handle exceptions, even over `return`
-(expect "Oh noes!" (wcar {} (->> (car/return (Exception. "boo"))
-                                 (car/parse
-                                  (-> #(if (instance? Exception %) "Oh noes!" %)
-                                      (with-meta {:parse-exceptions? true}))))))
+  (testing "Parsers can elect to handle exceptions, even over 'return'"
+    (is (= "Oh noes!" (wcar {} (->> (car/return (Exception. "boo"))
+                                    (car/parse
+                                     (-> #(if (instance? Exception %) "Oh noes!" %)
+                                         (with-meta {:parse-exceptions? true}))))))))
 
-;; Lua (`with-replies`) errors bypass normal parsers
-(expect Exception (wcar {} (->> (car/lua "invalid" {:_ :_} {}) (car/parse keyword))))
-(expect enc/bytes-class ; But _do_ maintain raw parsing metadata:
-  (do (wcar {} (car/set (tkey "binkey") (.getBytes "Foobar" "UTF-8")))
-      (wcar {} (-> (car/lua "return redis.call('get', _:k)" {:k (tkey "binkey")} {})
-                   (car/parse-raw)))))
+  (testing "Lua ('with-replies') errors bypass normal parsers"
+    (is (thrown? Exception (wcar {} (->> (car/lua "invalid" {:_ :_} {})
+                                         (car/parse keyword)))))
+    (is (instance? enc/bytes-class ;; But _do_ maintain raw parsing metadata:
+                   (do (wcar {} (car/set (tkey "binkey")
+                                         (.getBytes "Foobar" "UTF-8")))
+                       (wcar {} (-> (car/lua "return redis.call('get', _:k)"
+                                             {:k (tkey "binkey")} {})
+                                    (car/parse-raw)))))))
 
-;; Parsing passes `with-replies` barrier
-(expect [["ONE" "three"] "two"]
-  (let [p (promise)]
-    [(wcar {} (car/echo "ONE") (car/parse str/lower-case
-                                 (deliver p (car/with-replies (car/echo "TWO")))
-                                 (car/echo "THREE")))
-     @p]))
+  (testing "Parsing passes 'with-replies' barrier"
+    (is (= [["ONE" "three"] "two"]
+           (let [p (promise)]
+             [(wcar {} (car/echo "ONE") (car/parse str/lower-case
+                                                   (deliver p (car/with-replies (car/echo "TWO")))
+                                                   (car/echo "THREE")))
+              @p])))))
+
 
 ;;;; Request queues (experimental, for Carmine v3)
 ;; Pre v3, Redis command fns used to immediately trigger writes to their
@@ -433,180 +541,200 @@
 ;; Cluster mode. This is a trade-off: we now have to be careful to realize
 ;; queued requests any time a nested connection occurs.
 
-(expect ["OK" "echo"] (wcar {} (car/set (tkey "rq1") (wcar {} (car/echo "echo")))
-                               (car/get (tkey "rq1"))))
-(expect "rq2-val"
-  (let [p (promise)]
-    (wcar {} (car/del (tkey "rq2")))
-    (wcar {} (car/set (tkey "rq2") "rq2-val")
-          ;; Nested `wcar` here should trigger eager sending of queued writes
-          ;; above (to simulate immediate-write commands):
-          (deliver p (wcar {} (car/get (tkey "rq2")))))
-    @p))
-
-;;;; `atomic`
-
-(expect Exception    (car/atomic {} 1)) ; Missing multi
-(expect [["OK"] nil] (car/atomic {} 1 (car/multi))) ; Empty multi
-(expect Exception    (car/atomic {} 1 (car/multi) (car/discard))) ; Like missing multi
-
-(expect [["OK" "QUEUED"] "PONG"] (car/atomic {} 1 (car/multi) (car/ping)))
-(expect [["OK" "QUEUED" "QUEUED"] ["PONG" "PONG"]]
-        (car/atomic {} 1 (car/multi) (car/ping) (car/ping)))
-(expect [["echo" "OK" "QUEUED"] "PONG"]
-        (car/atomic {} 1 (car/return "echo") (car/multi) (car/ping)))
-
-(expect ArithmeticException ; Nb be specific here to distinguish from other exs!
-  (car/atomic {} 1
-    (car/multi)
-    (car/ping)
-    (/ 1 0) ; Throws client-side
-    (car/ping)))
-
-(expect Exception (car/atomic {} 1
-                    (car/multi)
-                    (car/redis-call [:invalid]) ; Server-side error, before exec
-                    (car/ping)))
-
-;; Ignores extra multi [error] while queuing:
-(expect "PONG" (-> (car/atomic {} 1 (car/multi) (car/multi) (car/ping))
-                   second))
-
-(expect "PONG" (-> (car/atomic {} 1
-                     (car/multi)
-                     (car/parse (constantly "foo") (car/ping)))
-                   second)) ; No parsers
-
-(expect Exception (car/atomic {} 5
-                    (car/watch (tkey :watched))
-                    (car/set (tkey :watched) (rand))
-                    (car/multi)
-                    (car/ping))) ; Contending changes to watched key
-
-;; As above, with contending write by different connection:
-(expect Exception (car/atomic {} 5
-                    (car/watch (tkey :watched))
-                    (wcar {} (car/set (tkey :watched) (rand)))
-                    (car/multi)
-                    (car/ping)))
-
-(expect [[["OK" "OK" "QUEUED"] "PONG"] 3]
-        (let [idx (atom 1)]
-          [(car/atomic {} 3
-             (car/watch (tkey :watched))
-             (when (< @idx 3)
-               (swap! idx inc)
-               (car/set (tkey :watched) (rand))) ; Contend only first 2 attempts
-             (car/multi)
-             (car/ping))
-           @idx]))
-
-(expect ArithmeticException ; Correct (unmasked) error
-  (car/atomic {} 1 (/ 1 0)))
+(deftest request-queues-tests
+  (is (= ["OK" "echo"] (wcar {} (car/set (tkey "rq1")
+                                         (wcar {} (car/echo "echo")))
+                             (car/get (tkey "rq1")))))
+  (is (= "rq2-val"
+         (let [p (promise)]
+           (wcar {} (car/del (tkey "rq2")))
+           (wcar {} (car/set (tkey "rq2") "rq2-val")
+                 ;; Nested `wcar` here should trigger eager sending of queued writes
+                 ;; above (to simulate immediate-write commands):
+                 (deliver p (wcar {} (car/get (tkey "rq2")))))
+           @p))))
 
 
-;;;; Cluster key hashing
+(deftest atomic-tests
+  (testing "Bad cases"
+    (is (thrown? Exception (car/atomic {} 1))
+        "should throw exception because multi command is missing")
 
-(expect [12182 5061 4813] [(commands/keyslot "foo")
-                           (commands/keyslot "bar")
-                           (commands/keyslot "baz")]) ; Basic hashing
+    (is (= [["OK"] nil]
+           (car/atomic {} 1 (car/multi)))
+        "Empty multi case")
 
-(expect (= (commands/keyslot "{user1000}.following")
-           (commands/keyslot "{user1000}.followers"))) ; Both hash on "user1000"
+    (is (thrown? Exception (car/atomic {} 1 (car/multi) (car/discard)))
+        "Like missing multi case"))
 
-(expect (not= (commands/keyslot "foo{}{bar}")
-              (commands/keyslot "bar"))) ; Only first {}'s non-empty content used
+  (testing "Basic tests"
+    (is (= [["OK" "QUEUED"] "PONG"] (car/atomic {} 1 (car/multi) (car/ping))))
+    (is (= [["OK" "QUEUED" "QUEUED"] ["PONG" "PONG"]]
+           (car/atomic {} 1 (car/multi) (car/ping) (car/ping))))
+    (is (= [["echo" "OK" "QUEUED"] "PONG"]
+           (car/atomic {} 1 (car/return "echo") (car/multi) (car/ping)))))
 
-(expect (= (commands/keyslot "foo{{bar}}")
-           (commands/keyslot "{bar"))) ; Content of first {}
+  (testing "Exception case"
+    (is (thrown? ArithmeticException ;; Nb be specific here to distinguish from other exs!
+                 (car/atomic {} 1
+                             (car/multi)
+                             (car/ping)
+                             (/ 1 0)    ; Throws client-side
+                             (car/ping))))
 
-(expect (= (commands/keyslot "foo{bar}{zap}")
-           (commands/keyslot "foo{bar}{zip}")
-           (commands/keyslot "baz{bar}{zip}"))) ; All hash on "bar"
+    (is (thrown? Exception (car/atomic {} 1
+                                       (car/multi)
+                                       (car/redis-call [:invalid]) ; Server-side error, before exec
+                                       (car/ping)))))
 
-(expect (not= (commands/keyslot "foo")
-              (commands/keyslot "FOO"))) ; Hashing is case sensitive
+  (testing "Multi Ping case"
+    (is (= "PONG" (-> (car/atomic {} 1 (car/multi) (car/multi) (car/ping))
+                      second))
+        "Ignores extra multi [error] while queuing:")
 
-;;; Hashing works over arbitrary bin keys
-(expect (= (commands/keyslot (byte-array [(byte 3) (byte 100) (byte 20)]))
-           (commands/keyslot (byte-array [(byte 3) (byte 100) (byte 20)]))))
-(expect (not= (commands/keyslot (byte-array [(byte 3) (byte 100) (byte 20)]))
-              (commands/keyslot (byte-array [(byte 3) (byte 100) (byte 21)]))))
+    (is (= "PONG" (-> (car/atomic {} 1
+                                  (car/multi)
+                                  (car/parse (constantly "foo") (car/ping)))
+                                        ; No parsers
+                      second))))
 
-;;;; Bin args
+  (is (thrown? Exception (car/atomic {} 5
+                                     (car/watch (tkey :watched))
+                                     (car/set (tkey :watched) (rand))
+                                     (car/multi)
+                                     (car/ping)))) ; Contending changes to watched key
 
-(expect (seq (.getBytes "Foobar" "UTF-8"))
-  (do (wcar {} (car/set (tkey "bin-arg") (.getBytes "Foobar" "UTF-8")))
-      (seq (wcar {} (car/get (tkey "bin-arg"))))))
+  ;; As above, with contending write by different connection:
+  (is (thrown? Exception (car/atomic {} 5
+                                     (car/watch (tkey :watched))
+                                     (wcar {} (car/set (tkey :watched) (rand)))
+                                     (car/multi)
+                                     (car/ping))))
 
-;;;; CAS stuff
+  (is (= [[["OK" "OK" "QUEUED"] "PONG"] 3]
+         (let [idx (atom 1)]
+           [(car/atomic {} 3
+                        (car/watch (tkey :watched))
+                        (when (< @idx 3)
+                          (swap! idx inc)
+                          (car/set (tkey :watched) (rand))) ; Contend only first 2 attempts
+                        (car/multi)
+                        (car/ping))
+            @idx])))
 
-(expect ["OK" 1 0 1 1 "final-val"]
-  (let [tk  (tkey "cas-k")
-        cas (partial car/compare-and-set tk)]
-    ;; (wcar {} (car/del tk))
-    (wcar {}
-      (car/set tk    0)
-      (cas 0         1)
-      (cas 22        23)  ; Will be ignored
-      (cas 1         nil) ; Serialized nil
-      (cas nil       "final-val")
-      (car/get tk))))
+  (is (thrown? ArithmeticException ;; Correct (unmasked) error
+               (car/atomic {} 1 (/ 1 0)))))
 
-(expect
-  ["state1" "state2" "state3" "RETURN" "state4" "state4" "OK"
-   [:this :is :a :big :value :needs :sha :woo]
-   :aborted "tx-value" "OK" :aborted "tx-value"]
 
-  (let [tk      (tkey "swap1")
-        big-val [:this :is :a :big :value :needs :sha]]
-    ;; (wcar {} (car/del tk)) ; Debug
-    (wcar {}
-      (car/swap tk (fn [?old nx?] (if nx? "state1" "_")))
-      (car/swap tk (fn [?old nx?] (if nx? "_" "state2")))
-      (car/swap tk (fn [?old _]   (if (= ?old "state2")  "state3" "_")))
-      (car/parse str/upper-case
-        (car/swap tk (fn [?old _] (enc/swapped "state4" "return"))))
-      (car/get  tk)
-      (car/swap tk (fn [?old _] (enc/swapped "state5" ?old)))
+(deftest cluster-key-hashing-tests
+  (is (= [12182 5061 4813] [(commands/keyslot "foo")
+                            (commands/keyslot "bar")
+                            (commands/keyslot "baz")])
+      "Basic hashing")
 
-      (car/set  tk big-val)
-      (car/swap tk (fn [?old nx?] (conj ?old :woo)))
+  (is (= (commands/keyslot "{user1000}.following")
+         (commands/keyslot "{user1000}.followers"))
+      "Both hash on 'user1000'")
 
-      (car/swap tk (fn [?old nx?] (wcar {} (car/set tk "non-tx-value")) "tx-value")
-        1 :aborted)
-      (car/swap tk (fn [?old nx?] (wcar {} (car/set tk "non-tx-value")) "tx-value")
-        2 :aborted)
+  (is (not= (commands/keyslot "foo{}{bar}")
+            (commands/keyslot "bar"))
+      "Only first {}'s non-empty content used")
 
-      (car/set tk big-val)
-      (car/swap tk (fn [?old nx?] (wcar {} (car/set tk "non-tx-value")) "tx-value")
-        1 :aborted)
-      (car/swap tk (fn [?old nx?] (wcar {} (car/set tk "non-tx-value")) "tx-value")
-        2 :aborted))))
+  (is (= (commands/keyslot "foo{{bar}}")
+         (commands/keyslot "{bar"))
+      "Content of first {}")
 
-(expect
-  ["nx" 1 1 "3" "tx-value1" :aborted "tx-value3" 0 ["nx" "val2" "tx-value3" "val4"]]
-  (let [tk (tkey "swap2")]
-    ;; (wcar {} (car/del tk)) ; Debug
-    (wcar {}
-      (car/hswap tk "field1" (fn [?old-val nx?] (if nx? "nx" "ex")))
-      (car/hset  tk "field2" "val2")
-      (car/hset  tk "field3" 3)
-      (car/hswap tk "field3" (fn [?old-val nx?] ?old-val))
+  (is (= (commands/keyslot "foo{bar}{zap}")
+         (commands/keyslot "foo{bar}{zip}")
+         (commands/keyslot "baz{bar}{zip}"))
+       "All hash on 'bar")
 
-      (car/hswap tk "field3"
-        (fn [?old nx?] (wcar {} (car/hset tk "field4" "non-tx-value1")) "tx-value1")
-        1 :aborted)
-      (car/hswap tk "field3"
-        (fn [?old nx?] (wcar {} (car/hset tk "field3" "non-tx-value2")) "tx-value2")
-        1 :aborted)
-      (car/hswap tk "field3"
-        (fn [?old nx?] (wcar {} (car/hset tk "field3" "non-tx-value3")) "tx-value3")
-        2 :aborted)
+  (is (not= (commands/keyslot "foo")
+            (commands/keyslot "FOO"))
+      "Hashing is case sensitive"))
 
-      (car/hset  tk "field4" "val4")
-      (car/hvals tk))))
 
-;;;; Benching
+(deftest hashing-arbitrary-bin-keys-tests
+  (is (= (commands/keyslot (byte-array [(byte 3) (byte 100) (byte 20)]))
+         (commands/keyslot (byte-array [(byte 3) (byte 100) (byte 20)]))))
 
-(expect (benchmarks/bench {}))
+  (is (not= (commands/keyslot (byte-array [(byte 3) (byte 100) (byte 20)]))
+            (commands/keyslot (byte-array [(byte 3) (byte 100) (byte 21)])))))
+
+
+(deftest bin-args-tests
+  (wcar {} (car/set (tkey "bin-arg")
+                    (.getBytes "Foobar" "UTF-8")))
+  (is (= (seq (.getBytes "Foobar" "UTF-8"))
+         (seq (wcar {} (car/get (tkey "bin-arg")))))))
+
+
+(deftest cas-tests
+  (is (= ["OK" 1 0 1 1 "final-val"]
+         (let [tk  (tkey "cas-k")
+               cas (partial car/compare-and-set tk)]
+           ;; (wcar {} (car/del tk))
+           (wcar {}
+                 (car/set tk    0)
+                 (cas 0         1)
+                 (cas 22        23)        ; Will be ignored
+                 (cas 1         nil)       ; Serialized nil
+                 (cas nil       "final-val")
+                 (car/get tk)))))
+
+  (is (= ["state1" "state2" "state3" "RETURN" "state4" "state4" "OK"
+          [:this :is :a :big :value :needs :sha :woo]
+          :aborted "tx-value" "OK" :aborted "tx-value"]
+
+         (let [tk      (tkey "swap1")
+               big-val [:this :is :a :big :value :needs :sha]]
+           ;; (wcar {} (car/del tk)) ; Debug
+           (wcar {}
+                 (car/swap tk (fn [?old nx?] (if nx? "state1" "_")))
+                 (car/swap tk (fn [?old nx?] (if nx? "_" "state2")))
+                 (car/swap tk (fn [?old _]   (if (= ?old "state2")  "state3" "_")))
+                 (car/parse str/upper-case
+                            (car/swap tk (fn [?old _] (enc/swapped "state4" "return"))))
+                 (car/get  tk)
+                 (car/swap tk (fn [?old _] (enc/swapped "state5" ?old)))
+
+                 (car/set  tk big-val)
+                 (car/swap tk (fn [?old nx?] (conj ?old :woo)))
+
+                 (car/swap tk (fn [?old nx?] (wcar {} (car/set tk "non-tx-value")) "tx-value")
+                           1 :aborted)
+                 (car/swap tk (fn [?old nx?] (wcar {} (car/set tk "non-tx-value")) "tx-value")
+                           2 :aborted)
+
+                 (car/set tk big-val)
+                 (car/swap tk (fn [?old nx?] (wcar {} (car/set tk "non-tx-value")) "tx-value")
+                           1 :aborted)
+                 (car/swap tk (fn [?old nx?] (wcar {} (car/set tk "non-tx-value")) "tx-value")
+                           2 :aborted)))))
+
+  (is (= ["nx" 1 1 "3" "tx-value1" :aborted "tx-value3"
+          0 ["nx" "val2" "tx-value3" "val4"]]
+   (let [tk (tkey "swap2")]
+     ;; (wcar {} (car/del tk)) ; Debug
+     (wcar {}
+           (car/hswap tk "field1" (fn [?old-val nx?] (if nx? "nx" "ex")))
+           (car/hset  tk "field2" "val2")
+           (car/hset  tk "field3" 3)
+           (car/hswap tk "field3" (fn [?old-val nx?] ?old-val))
+
+           (car/hswap tk "field3"
+                      (fn [?old nx?] (wcar {} (car/hset tk "field4" "non-tx-value1")) "tx-value1")
+                      1 :aborted)
+           (car/hswap tk "field3"
+                      (fn [?old nx?] (wcar {} (car/hset tk "field3" "non-tx-value2")) "tx-value2")
+                      1 :aborted)
+           (car/hswap tk "field3"
+                      (fn [?old nx?] (wcar {} (car/hset tk "field3" "non-tx-value3")) "tx-value3")
+                      2 :aborted)
+
+           (car/hset  tk "field4" "val4")
+           (car/hvals tk))))))
+
+
+(deftest benchmarks-tests
+  (is (true? (benchmarks/bench {}))))

--- a/test/taoensso/carmine/tests/tundra.clj
+++ b/test/taoensso/carmine/tests/tundra.clj
@@ -1,5 +1,5 @@
 (ns taoensso.carmine.tests.tundra
-  (:require [expectations     :as test :refer :all]
+  (:require [clojure.test :refer :all]
             [taoensso.carmine :as car  :refer (wcar)]
             [taoensso.carmine.message-queue :as mq]
             [taoensso.carmine.tundra        :as tundra]
@@ -12,6 +12,8 @@
 (def tkey (partial car/key :carmine :tundra :test))
 (def tqname "carmine-tundra-tests")
 (def mqname (format "tundra:%s" (name tqname))) ; Nb has prefix
+
+
 (defn clean-up! []
   (mq/clear-queues {} mqname)
   (when-let [ks (seq (wcar* (car/keys (tkey :*))))]
@@ -19,8 +21,15 @@
            (apply car/srem @#'tundra/k-evictable ks)))
   (wcar* (car/srem @#'tundra/k-evictable (tkey :invalid-evictable))))
 
-(defn- before-run {:expectations-options :before-run} [] (clean-up!))
-(defn- after-run  {:expectations-options :after-run}  [] (clean-up!))
+
+(defn cleanup-fixture
+  [f]
+  (clean-up!)
+  (f)
+  (clean-up!))
+
+(use-fixtures :once cleanup-fixture)
+
 
 (defonce s3-creds {:access-key (get (System/getenv) "AWS_S3_ACCESS_KEY")
                    :secret-key (get (System/getenv) "AWS_S3_SECRET_KEY")})
@@ -32,97 +41,117 @@
 
 ;;;; S3 DataStore
 
-(expect (and (:access-key s3-creds) (:secret-key s3-creds)))
+(deftest s3-tests
+  (is (true? (and (:access-key s3-creds)
+                  (:secret-key s3-creds))))
 
-(expect "hello world" ; Basic put & fetch
-  (do (tundra/put-key dstore (tkey :foo) (s->ba "hello world"))
-      (-> (tundra/fetch-keys dstore [(tkey :foo)]) (first) (ba->s))))
+  (testing "Basic put and fetch case"
+    (tundra/put-key dstore (tkey :foo) (s->ba "hello world"))
+    (is (= "hello world"
+           (-> dstore
+               (tundra/fetch-keys [(tkey :foo)])
+               first
+               ba->s))))
 
-(expect "hello world 2" ; Update val
-  (do (tundra/put-key dstore (tkey :foo) (s->ba "hello world 1"))
-      (tundra/put-key dstore (tkey :foo) (s->ba "hello world 2"))
-      (-> (tundra/fetch-keys dstore [(tkey :foo)]) (first) (ba->s))))
+  (testing "Update val case"
+    (tundra/put-key dstore (tkey :foo) (s->ba "hello world 1"))
+    (tundra/put-key dstore (tkey :foo) (s->ba "hello world 2"))
+    (is (= "hello world 2"
+           (-> dstore
+               (tundra/fetch-keys [(tkey :foo)])
+               first
+               ba->s))))
 
-(expect AmazonS3Exception (first (tundra/fetch-keys dstore [(tkey :invalid)])))
+  (testing "Exception Case"
+    (is (thrown? AmazonS3Exception
+                 (first (tundra/fetch-keys dstore [(tkey :invalid)]))))))
 
-;;;; Tundra API
 
-(let [tstore (tundra/tundra-store dstore)]
-  (expect Exception (wcar* (tundra/dirty     tstore (tkey :invalid))))
-  (expect nil       (wcar* (tundra/ensure-ks tstore (tkey :invalid))))
-  (expect Exception (wcar* (car/sadd @#'tundra/k-evictable (tkey :invalid-evictable))
-                           (tundra/ensure-ks tstore (tkey :invalid-evictable))))
+(deftest tundra-api-test-1
+  (let [tstore (tundra/tundra-store dstore)]
+    (testing "Bad cases"
+      (is (thrown? Exception (wcar* (tundra/dirty tstore (tkey :invalid)))))
+      (is (= nil (wcar* (tundra/ensure-ks tstore (tkey :invalid)))))
+      (is (thrown? Exception
+                   (wcar* (car/sadd @#'tundra/k-evictable (tkey :invalid-evictable))
+                          (tundra/ensure-ks tstore (tkey :invalid-evictable))))))
 
-  ;; API never pollutes enclosing pipeline
-  (expect ["OK" "PONG" 1]
-    (wcar* (car/set (tkey 0) "0")
-           (car/ping)
-           ;; Won't throw since `(tkey :invalid)` isn't in evictable set:
-           (tundra/ensure-ks tstore (tkey 0) (tkey :invalid))
-           (tundra/dirty     tstore (tkey 0))
-           (car/del (tkey 0) "0"))))
+    (testing "API never pollutes enclosing pipeline"
+      (is (= ["OK" "PONG" 1]
+             (wcar* (car/set (tkey 0) "0")
+                    (car/ping)
+                    ;; Won't throw since `(tkey :invalid)` isn't in evictable set:
+                    (tundra/ensure-ks tstore (tkey 0) (tkey :invalid))
+                    (tundra/dirty     tstore (tkey 0))
+                    (car/del (tkey 0) "0")))))))
 
-(expect [[:clj-val] [:clj-val] [:clj-val-new]]
-  (let [_       (clean-up!)
-        tstore  (tundra/tundra-store dstore {:tqname tqname})
-        tworker (tundra/worker tstore {} {:eoq-backoff-ms 100 :throttle-ms 100})]
 
-    (wcar* (car/mset (tkey 0) [:clj-val]
-                     (tkey 1) [:clj-val]
-                     (tkey 2) [:clj-val])) ; Reset vals
+(deftest tundra-api-test-2
+  (is (= [[:clj-val] [:clj-val] [:clj-val-new]]
+         (let [_       (clean-up!)
+               tstore  (tundra/tundra-store dstore {:tqname tqname})
+               tworker (tundra/worker tstore {} {:eoq-backoff-ms 100 :throttle-ms 100})]
 
-    ;; Invalid keys don't prevent valid keys from being processed (will still
-    ;; throw, but only _after_ all possible dirtying):
-    (wcar* (try (tundra/dirty tstore (tkey :invalid) (tkey :invalid-evictable)
+           (wcar* (car/mset (tkey 0) [:clj-val]
+                            (tkey 1) [:clj-val]
+                            (tkey 2) [:clj-val])) ; Reset vals
+
+           ;; Invalid keys don't prevent valid keys from being processed (will still
+           ;; throw, but only _after_ all possible dirtying):
+           (wcar* (try (tundra/dirty tstore (tkey :invalid) (tkey :invalid-evictable)
                                      (tkey 0) (tkey 1) (tkey 2))
-                (catch Exception _ nil)))
+                       (catch Exception _ nil)))
 
-    (Thread/sleep 8000) ; Wait for replication
-    (mq/stop tworker)
-    (wcar* (car/del (tkey 0))
-           (car/set (tkey 2) [:clj-val-new])) ; Make some local modifications
+           (Thread/sleep 8000)          ; Wait for replication
+           (mq/stop tworker)
+           (wcar* (car/del (tkey 0))
+                  (car/set (tkey 2) [:clj-val-new])) ; Make some local modifications
 
-    ;; Invalid keys don't prevent valid keys from being processed (will still
-    ;; throw, but only _after_ all possible fetches)
-    (wcar* (try (tundra/ensure-ks tstore (tkey :invalid) (tkey :invalid-evictable)
+           ;; Invalid keys don't prevent valid keys from being processed (will still
+           ;; throw, but only _after_ all possible fetches)
+           (wcar* (try (tundra/ensure-ks tstore (tkey :invalid) (tkey :invalid-evictable)
                                          (tkey 0) (tkey 1) (tkey 2))
-                (catch Exception _ nil)))
+                       (catch Exception _ nil)))
 
-    (wcar* (car/mget (tkey 0) (tkey 1) (tkey 2)))))
+           (wcar* (car/mget (tkey 0) (tkey 1) (tkey 2)))))))
 
-(expect [-1 -1 -1] ; nil eviction timeout (default) is respected!
-  (let [tstore  (tundra/tundra-store dstore {:tqname tqname})
-        tworker (tundra/worker tstore {} {:eoq-backoff-ms 100 :throttle-ms 100})]
-    (wcar* (car/mset (tkey 0) "0" (tkey 1) "1" (tkey 2) "1") ; Clears timeouts
-           (tundra/dirty tstore (tkey 0) (tkey 1) (tkey 2)))
-    (Thread/sleep 8000) ; Wait for replication
-    (mq/stop tworker)
-    (wcar* (tundra/ensure-ks tstore (tkey 0) (tkey 1) (tkey 2))
-           (mapv #(car/ttl (tkey %)) [0 1 2]))))
 
-(expect ; nnil eviction timeout is applied & extended correctly
- (fn [[t0 t1 t2]]
-   (and (= t0 -1)
-        (> t1  0)
-        (> t2  t1)))
+(deftest tundra-api-test-3
+  (is (= [-1 -1 -1]        ; nil eviction timeout (default) is respected!
+         (let [tstore  (tundra/tundra-store dstore {:tqname tqname})
+               tworker (tundra/worker tstore {} {:eoq-backoff-ms 100 :throttle-ms 100})]
+           (wcar* (car/mset (tkey 0) "0" (tkey 1) "1" (tkey 2) "1") ; Clears timeouts
+                  (tundra/dirty tstore (tkey 0) (tkey 1) (tkey 2)))
+           (Thread/sleep 8000)             ; Wait for replication
+           (mq/stop tworker)
+           (wcar* (tundra/ensure-ks tstore (tkey 0) (tkey 1) (tkey 2))
+                  (mapv #(car/ttl (tkey %)) [0 1 2]))))))
 
- (let [_       (clean-up!)
-       tstore  (tundra/tundra-store dstore {:redis-ttl-ms (* 1000 60 60 24)
-                                            :tqname tqname})
-       tworker (tundra/worker tstore {} {:eoq-backoff-ms 100 :throttle-ms 100
-                                         :auto-start false})]
 
-   (wcar* (car/set (tkey 0) "0") ; Clears timeout
-          (tundra/dirty tstore (tkey 0)))
+(deftest tundra-api-test-4
+  (testing "nnil eviction timeout is applied & extended correctly"
+    (is (= (fn [[t0 t1 t2]]
+             (and (= t0 -1)
+                  (> t1  0)
+                  (> t2  t1)))
 
-   [(wcar* (car/pttl (tkey 0))) ; `dirty` doesn't set ttl immediately
-    (do (mq/start tworker)
-        (Thread/sleep 5000) ; Wait for replication (> exp-backoff)
-        (mq/stop tworker)
-        (wcar* (car/pttl (tkey 0)))) ; Worker sets ttl after successful put
-    (do (Thread/sleep 1000)
-        (wcar* (tundra/ensure-ks tstore (tkey 0))
-               (car/pttl (tkey 0))))]))
+           (let [_       (clean-up!)
+                 tstore  (tundra/tundra-store dstore {:redis-ttl-ms (* 1000 60 60 24)
+                                                      :tqname tqname})
+                 tworker (tundra/worker tstore {} {:eoq-backoff-ms 100 :throttle-ms 100
+                                                   :auto-start false})]
+
+             (wcar* (car/set (tkey 0) "0") ; Clears timeout
+                    (tundra/dirty tstore (tkey 0)))
+
+             [(wcar* (car/pttl (tkey 0))) ; `dirty` doesn't set ttl immediately
+              (do (mq/start tworker)
+                  (Thread/sleep 5000) ; Wait for replication (> exp-backoff)
+                  (mq/stop tworker)
+                  (wcar* (car/pttl (tkey 0)))) ; Worker sets ttl after successful put
+              (do (Thread/sleep 1000)
+                  (wcar* (tundra/ensure-ks tstore (tkey 0))
+                         (car/pttl (tkey 0))))])))))
 
 (comment (clean-up!)
          (mq/queue-status {} mqname))


### PR DESCRIPTION
Migration from expectations to clojure.test is done.
Please run all the tests yourself once as well as I haven't run tundra tests (I haven't tried to migrate tundra S3 tests to local disk yet).

Here's the test output that I ran:
```
$ lein with-profile "+1.9:+1.8:+1.7:+1.6:+1.5" test taoensso.carmine.tests.main taoensso.carmine.tests.locks taoensso.carmine.tests.message-queue

Performing task 'test' with profile(s): 'base,system,user,provided,dev,1.9'

lein test taoensso.carmine.tests.main

Benching (this can take some time)
----------------------------------

Lap 1/1...
{:wcar 95, :ping 517, :set 433, :get 656, :roundtrip 613, :ping-pipelined 2143}

Done! (Time for cake?)

lein test taoensso.carmine.tests.locks

lein test taoensso.carmine.tests.message-queue

Ran 51 tests containing 191 assertions.
0 failures, 0 errors.
Performing task 'test' with profile(s): 'base,system,user,provided,dev,1.8'

lein test taoensso.carmine.tests.main

Benching (this can take some time)
----------------------------------

Lap 1/1...
{:wcar 97, :ping 615, :set 480, :get 597, :roundtrip 575, :ping-pipelined 2203}

Done! (Time for cake?)

lein test taoensso.carmine.tests.locks

lein test taoensso.carmine.tests.message-queue

Ran 51 tests containing 191 assertions.
0 failures, 0 errors.
Performing task 'test' with profile(s): 'base,system,user,provided,dev,1.7'

lein test taoensso.carmine.tests.main

Benching (this can take some time)
----------------------------------

Lap 1/1...
{:wcar 126, :ping 592, :set 457, :get 478, :roundtrip 567, :ping-pipelined 2200}

Done! (Time for cake?)

lein test taoensso.carmine.tests.locks

lein test taoensso.carmine.tests.message-queue

Ran 51 tests containing 191 assertions.
0 failures, 0 errors.
Performing task 'test' with profile(s): 'base,system,user,provided,dev,1.6'

lein test taoensso.carmine.tests.main

Benching (this can take some time)
----------------------------------

Lap 1/1...
{:wcar 92, :ping 618, :set 491, :get 548, :roundtrip 572, :ping-pipelined 2147}

Done! (Time for cake?)

lein test taoensso.carmine.tests.locks

lein test taoensso.carmine.tests.message-queue

Ran 51 tests containing 191 assertions.
0 failures, 0 errors.
Performing task 'test' with profile(s): 'base,system,user,provided,dev,1.5'

lein test taoensso.carmine.tests.main

Benching (this can take some time)
----------------------------------

Lap 1/1...
{:wcar 45, :ping 478, :set 429, :get 462, :roundtrip 542, :ping-pipelined 2199}

Done! (Time for cake?)

lein test taoensso.carmine.tests.locks

lein test taoensso.carmine.tests.message-queue

Ran 51 tests containing 191 assertions.
0 failures, 0 errors.
```

Let me know if there's something I missed.
Thanks :)