### PR TITLE
Add ssl option for connection spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ A simple example spec with no pool and one server using redistogo.com would be:
 (def server1-conn {:pool {} :spec {:uri \"redis://redistogo:pass@panga.redistogo.com:9475/\"}})
 ```
 
+#### Secure connections via SSL
+
+To connect to redis via SSL you can pass a `:ssl` flag like so:
+
+```clojure
+(def secure-conn {:pool {} :spec {:host "redis.in.your.cloud.com" :port 443 :ssl true :password "secret"}}
+```
+
 ### Basic commands
 
 Executing commands is easy:

--- a/test/taoensso/carmine/tests/connections.clj
+++ b/test/taoensso/carmine/tests/connections.clj
@@ -8,5 +8,4 @@
     (is (= (#'conn/ssl-socket-factory) (#'conn/ssl-socket-factory))
         "returns the same instance every time")
     (is (instance? SSLSocketFactory (#'conn/ssl-socket-factory))
-        "is instance of type SSLSocketFactory"))
-  )
+        "is instance of type SSLSocketFactory")))

--- a/test/taoensso/carmine/tests/connections.clj
+++ b/test/taoensso/carmine/tests/connections.clj
@@ -1,0 +1,8 @@
+(ns taoensso.carmine.tests.connections
+  (:require  [clojure.test :refer :all]
+             [taoensso.carmine.connections :as conn]))
+
+(deftest ssl-socket-factory
+  (testing "socket factory should be cached"
+    (is (= (#'conn/ssl-socket-factory) (#'conn/ssl-socket-factory))))
+  )

--- a/test/taoensso/carmine/tests/connections.clj
+++ b/test/taoensso/carmine/tests/connections.clj
@@ -1,8 +1,12 @@
 (ns taoensso.carmine.tests.connections
-  (:require  [clojure.test :refer :all]
-             [taoensso.carmine.connections :as conn]))
+  (:require [clojure.test :refer :all]
+            [taoensso.carmine.connections :as conn])
+  (:import (javax.net.ssl SSLSocketFactory)))
 
 (deftest ssl-socket-factory
-  (testing "socket factory should be cached"
-    (is (= (#'conn/ssl-socket-factory) (#'conn/ssl-socket-factory))))
+  (testing "socket factory"
+    (is (= (#'conn/ssl-socket-factory) (#'conn/ssl-socket-factory))
+        "returns the same instance every time")
+    (is (instance? SSLSocketFactory (#'conn/ssl-socket-factory))
+        "is instance of type SSLSocketFactory"))
   )


### PR DESCRIPTION
Hey Peter,
I really like carmine and have used it successfully for quite a while now.
Now I have to move a considerable code base to AWS and therefore also use ElastiCache. Since all traffic inside the AWS has to somehow be encrypted, I need a ssl parameter for our carmine connections. I know that this has been [discussed already](https://github.com/ptaoussanis/carmine/issues/151), but the cloud aspect was not mentioned there and so we thought I would give it another try.

Please see the pull request as a very rudimentary proposed implementation that I would further refine if you're open to the idea.