### PR TITLE
monitor-fn: log mid-circle-size as intented

### DIFF
--- a/src/taoensso/carmine/message_queue.clj
+++ b/src/taoensso/carmine/message_queue.clj
@@ -301,7 +301,7 @@
           (when (> (- instant udt-last-warning) (or warn-backoff-ms 0))
             (when (compare-and-set! udt-last-warning_ udt-last-warning instant)
               (timbre/warnf "Message queue size warning: %s (mid-circle-size: %s)"
-                qname max-circle-size))))))))
+                qname mid-circle-size))))))))
 
 (defn worker
   "Returns a threaded worker to poll for and handle messages `enqueue`'d to


### PR DESCRIPTION
When the queue size exceeds max-circle-size, a warn message is logged.
It was logging the max size when it was supposed to log the actual size