### PR TITLE
Add deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,7 @@
+{:deps
+ {org.clojure/clojure #:mvn{:version "1.5.1"},
+  com.taoensso/encore #:mvn{:version "2.94.0"},
+  com.taoensso/timbre #:mvn{:version "4.10.0"},
+  com.taoensso/nippy #:mvn{:version "2.14.0"},
+  org.apache.commons/commons-pool2 #:mvn{:version "2.4.2"},
+  commons-codec/commons-codec #:mvn{:version "1.11"}}}


### PR DESCRIPTION
This helps in using carmine with `clj` tool. `deps.edn` is generated with the script https://gist.github.com/swlkr/3f346c66410e5c60c59530c4413a248e . I have verified it's usage locally with below deps.edn file.

deps.edn

```clojure
{
 :deps {
        carmine {:git/url "https://github.com/tirkarthi/carmine.git" 
                 :sha "24033a2ce8fed255f7473ac80cc401be68a248db"}
        }
 }
```

Thanks