### PR TITLE
Mistake in docs, swap with-lock arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,8 +320,8 @@ See the relevant [API] docs for details.
 ```clojure
 (:require [taoensso.carmine.locks :as locks]) ; Add to `ns` macro
 
-(locks/with-lock "my-lock"
-  {:pool {<opts>} :spec {<opts>}} ; Connection details
+(locks/with-lock {:pool {<opts>} :spec {<opts>}} ; Connection details
+  "my-lock"
   1000 ; Time to hold lock
   500  ; Time to wait (block) for lock acquisition
   (println "This was printed under lock!"))


### PR DESCRIPTION
Previous throws Connection refused, because of wrong argument postition