### PR TITLE
Match up max-total-per-key max-idle-per-key to avoid connections closing

### DIFF
--- a/src/taoensso/carmine/connections.clj
+++ b/src/taoensso/carmine/connections.clj
@@ -170,6 +170,7 @@
                }
               carmine-defaults
               {:max-total-per-key 16 ; from 8
+               :max-idle-per-key 16 ; needs to be the same value as above to avoid early connection closing
                }]
           (ConnectionPool.
             (reduce-kv set-pool-option


### PR DESCRIPTION
- Without this change, when under load, connections will be immediately closed upon return to the pool