### PR TITLE
Add callback functions for instrumentation

### DIFF
--- a/src/taoensso/carmine.clj
+++ b/src/taoensso/carmine.clj
@@ -79,7 +79,16 @@
   (wcar {} (echo 1) (println (with-replies (ping))) (echo 2))
   (wcar {} (echo 1) (println (with-replies :as-pipeline (ping))) (echo 2))
   (def setupf (fn [_] (println "boo")))
-  (wcar {:spec {:conn-setup-fn setupf}}))
+  (wcar {:spec {:conn-setup-fn setupf}})
+
+  (def conn-close-fn (fn [{spec :spec}] (println spec)))
+  (wcar {:spec {:conn-close-fn conn-close-fn}})
+
+  (def conn-open-fn (fn [{spec :spec}] (println spec)))
+  (wcar {:spec {:conn-open-fn conn-open-fn}})
+
+  (def conn-error-fn (fn [{spec :spec ex :ex}] (println ex)))
+  (wcar {:spec {:conn-error-fn conn-error-fn}}))
 
 (comment
   (wcar {}

--- a/test/taoensso/carmine/tests/main.clj
+++ b/test/taoensso/carmine/tests/main.clj
@@ -12,7 +12,32 @@
   (remove-ns      'taoensso.carmine.tests.main)
   (test/run-tests 'taoensso.carmine.tests.main))
 
-(defmacro wcar* [& body] `(car/wcar {:pool {} :spec {}} ~@body))
+(defn conn-setup [_]
+  (car/client-setname "the-name"))
+
+(defn conn-error [{spec :spec ex :ex}]
+  (let [tags {:redis-host (:host spec)
+              :redis-port (:port spec)
+              :redis-db (:db spec)}]))
+
+(defn conn-close [{spec :spec}]
+  (let [tags {:redis-host (:host spec)
+              :redis-port (:port spec)
+              :redis-db (:db spec)}]))
+
+(defn conn-open [{spec :spec}]
+  (let [tags {:redis-host (:host spec)
+              :redis-port (:port spec)
+              :redis-db (:db spec)}]))
+
+(defn pool-create [{pool :pool}])
+
+(defmacro wcar* [& body] `(car/wcar {:pool {:pool-create-fn pool-create}
+                                     :spec {:conn-setup-fn conn-setup
+                                            :conn-error-fn conn-error
+                                            :conn-close-fn conn-close
+                                            :conn-open-fn conn-open}} ~@body))
+
 (def tkey (partial car/key :carmine :temp :test))
 (defn clean-up-tkeys! [] (when-let [ks (seq (wcar* (car/keys (tkey :*))))]
                            (wcar* (apply car/del ks))))


### PR DESCRIPTION
These changes have been valuable to us here at CircleCI, as they can be used to produce detailed metrics about the connection pool's status.