### PR TITLE
Show additional error message when creating new listener.

### DIFF
--- a/src/taoensso/carmine.clj
+++ b/src/taoensso/carmine.clj
@@ -434,7 +434,8 @@
                         (try
                           (@handler-atom# reply# @state-atom#)
                           (catch Throwable t#
-                            (timbre/error t# "Listener handler exception")))))))]
+                            (timbre/error t# "Listener handler exception")
+                            (timbre/error (ex-message t#))))))))]
 
      (protocol/with-context conn# ~@body
        (protocol/execute-requests (not :get-replies) nil))


### PR DESCRIPTION
The following code will print only "Listener handler exception" during subscription. Which doesn't help much.

``` clojure
(car/with-new-pubsub-listener (:spec conn)
  {"update-db"
   (fn [[op _ [opts data]]]
     ,,,)}
      
  (car/subscribe "update-db"))
```

With the added `ex-message` one will also also get "nth not supported on this type: Long".