### PR TITLE
Added link to carmine-streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Link                     | Description
 ------------------------ | -----------------------------------------------------
 [@lantiga/redlock-clj]   | Distributed locks for uncoordinated Redis clusters
 [@danielsz/system]       | PubSub component for system
+[@oliyh/carmine-streams](https://github.com/oliyh/carmine-streams) | Higher order stream functionality including consumers and message rebalancing
 Your link here?          | **PR's welcome!**
 
 ## Getting started


### PR DESCRIPTION
Hi,

Thanks for carmine, it has been a pleasure working with redis using it.

I started using streams on a couple of projects and discovered there was a lot of common code around consuming from a stream with error handling. I wrote carmine-streams to provide this for the most common use cases.

I tried to link using just `[@oliyh/carmine-streams]` but it didn't turn into a link, I have no idea why, unless because I have not contributed to this repo before.

Thanks