### PR TITLE
[WIP] Adds minimal deps.edn and fix ring middleware session expiration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ pom.xml*
 /doc/
 .idea/
 *.iml
+/.cpcache/
+/.clj-kondo/
+/.lsp/

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,10 @@
+{:paths ["src"]
+
+ :deps {com.taoensso/encore {:mvn/version "3.9.2"}
+        com.taoensso/timbre {:mvn/version "5.1.0"}
+        com.taoensso/nippy {:mvn/version "3.1.1"}
+        org.apache.commons/commons-pool2 {:mvn/version "2.9.0"}
+        commons-codec/commons-codec {:mvn/version "1.15"}}
+
+ #_#_:mvn/repos {"sonatype-oss-public"
+             {:url "https://oss.sonatype.org/content/groups/public/"}}}

--- a/src/taoensso/carmine/ring.clj
+++ b/src/taoensso/carmine/ring.clj
@@ -7,7 +7,10 @@
 
 (defrecord CarmineSessionStore [conn-opts prefix ttl-secs]
   ring.middleware.session.store/SessionStore
-  (read-session   [_ k] (wcar conn-opts (car/get k)))
+  (read-session   [_ k] (wcar conn-opts
+                              (when-let [session (car/get k)]
+                                (when ttl-secs (car/expire k ttl-secs))
+                                session)))
   (delete-session [_ k] (wcar conn-opts (car/del k)) nil)
   (write-session  [_ k data]
     (let [k (or k (str prefix ":" (enc/uuid-str)))]


### PR DESCRIPTION
I added a minimal `deps.edn` file that only lists Carmine's dependencies, so that I can use Carmine from my tools.deps based project.

UPDATE:

As this doesn't seem to be maintained anymore, I'm saving myself the trouble of splitting two separate pull requests and also fix #259 in this pull request; I'll keep using my own fork. In case a maintainer wants to pick this up and prefers things differently, I'd be happy to oblige, but I'll save myself the effort until that happens :)