### PR TITLE
Correct misleading readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ You can force automatic de/serialization for an argument of any type by wrapping
 
 ### Documentation and command coverage
 
-Like [labs-redis-clojure], Carmine uses the [official Redis command reference] to generate its own command API. Which means that not only is Carmine's command coverage *always complete*, but it's also **fully documented**:
+Like [labs-redis-clojure], Carmine uses the [official Redis command reference] to generate its own command API. Which means that not only is Carmine's command coverage complete with the Redis version at the time of build, but it's also **fully documented**:
 
 ```clojure
 (use 'clojure.repl)


### PR DESCRIPTION
> "Which means that not only is Carmine's command coverage *always complete*,..."

This seems not true as far as I can tell. For example, the official Redis command reference has [`LMOVE`](https://github.com/redis/redis-doc/blob/master/commands.json#L7744) (introduced in v6.2.0) but this is not in the current version 3.0.0 of Carmine.

I appreciate there's an effort in keeping Carmine up to date with the latest and greatest Redis has to offer but saying it's "*always complete*" is misleading.