### PR TITLE
Only provide username for ACL if username is non-empty

### DIFF
--- a/src/taoensso/carmine/connections.clj
+++ b/src/taoensso/carmine/connections.clj
@@ -210,15 +210,16 @@
     (let [^URI uri (if (instance? URI uri) uri (URI. uri))
           [username password] (.split (str (.getUserInfo uri)) ":")
           port (.getPort uri)
-          db (if-let [[_ db-str] (re-matches #"/(\d+)$" (.getPath uri))]
+          db (when-let [[_ db-str] (re-matches #"/(\d+)$" (.getPath uri))]
                (Integer. ^String db-str))]
       (-> {:host (.getHost uri)}
-          (#(if (pos? port)        (assoc % :port     port)     %))
-          (#(if (and db (pos? db)) (assoc % :db       db)       %))
-          (#(if username           (assoc % :username username) %))
-          (#(if password           (assoc % :password password) %))))))
+          (#(if (pos? port)             (assoc % :port     port)     %))
+          (#(if (and db (pos? db))      (assoc % :db       db)       %))
+          (#(if (pos? (count username)) (assoc % :username username) %))
+          (#(if password                (assoc % :password password) %))))))
 
-(comment (parse-uri "redis://redistogo:pass@panga.redistogo.com:9475/7"))
+(comment (parse-uri "redis://redistogo:pass@panga.redistogo.com:9475/7")
+         (parse-uri "redis://:pass@panga.redistogo.com:9475/7"))
 
 (def conn-spec
   (enc/memoize


### PR DESCRIPTION
Issue: When given a URI like `redis://:pass@localhost:6379-/`, Carmine 3.1.0 would authenticate to Redis using only password, while Carmine 3.2.0 now passes an empty string `""` as username to Redis. This is a breaking change.

Fix: Only add username to connection spec when it's parsed as a non-empty string. Another option is to supply the implicit `default` username that Redis uses when no username is provided.