### PR TITLE
[doc] Enhance wcar docs to include timeout information

### DIFF
--- a/src/taoensso/carmine.clj
+++ b/src/taoensso/carmine.clj
@@ -81,7 +81,9 @@
          :ssl-fn :default ; [1]
          :username \"alice\"
          :password \"secret\"
-         :timeout-ms 6000
+         :timeout-ms 6000 ; Conn + read timeout in milliseconds
+         :conn-timeout-ms 5000 ; Conn timeout only in milliseconds
+         :read-timeout-ms 4000 ; Read timeout only in milliseconds
          :db 3}
 
     `pool` may be:


### PR DESCRIPTION
Hi @ptaoussanis,
I've found that the details around how to specify Socket and Connection timeouts for Carmine could be better documented and a little more accessible, I've added this small change to the `wcar` docstring.
However I think it'd be great if you could add some details to the Wiki around how to specify :timeout-ms, :read-timeout-ms, and :conn-timeout-ms and what their purpose is.
Some strong encouragement towards making sure these timeouts are specified when using Carmine would also be good, due to how Socket communications work in Java and that to my knowledge a socket read or connect cannot be interrupted.

Below is a minimal example of what can happen if the socket timeout is never specified, some users may not be aware of this:
```clojure
(with-open [sock (java.net.ServerSocket. 0)]
  (let [socket-uri (format "redis://localhost:%s/" (.getLocalPort sock))]
     (wcar {:spec {:uri socket-uri}}
       (car/ping)))
  (println "this code will never be reached due to hanging socket, and no timeout"))
```